### PR TITLE
Property api

### DIFF
--- a/RepairsApi.Tests/ApiMocking/ApiMockTest.cs
+++ b/RepairsApi.Tests/ApiMocking/ApiMockTest.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace RepairsApi.Tests.ApiMocking
+{
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "<Pending>")]
+    public class StaticApiMockTest
+    {
+        [Test]
+        public async Task ApiMockerWorksWithStaticMethods()
+        {
+            var mock = MockHttpMessageHandler.FromClass<StaticApiMockTest>();
+
+            HttpClient client = new HttpClient(mock);
+
+            var result = await client.GetAsync(new Uri("http://test/routetest?query=querytest"));
+
+            var stringResult = await result.Content.ReadAsStringAsync();
+            var response = JsonConvert.DeserializeObject<TestResult>(stringResult);
+
+            response.Route.Should().Be("routetest");
+            response.Query.Should().Be("querytest");
+
+            mock.Dispose();
+        }
+
+        [Test]
+        public async Task ApiMockerWorksWithInstancedMethods()
+        {
+            var mock = MockHttpMessageHandler.FromObject(new InstancedApiMockTest("testinstance"));
+
+            HttpClient client = new HttpClient(mock);
+
+            var result = await client.GetAsync(new Uri("http://test/routetest?query=querytest"));
+
+            var stringResult = await result.Content.ReadAsStringAsync();
+            var response = JsonConvert.DeserializeObject<TestResult>(stringResult);
+
+            response.Route.Should().Be("routetest");
+            response.Query.Should().Be("querytest");
+            response.Instance.Should().Be("testinstance");
+
+            mock.Dispose();
+        }
+
+        [Route("http://test/{fromRoute}")]
+        public static TestResult TestMethod(string fromRoute, string query)
+        {
+            return new TestResult
+            {
+                Route = fromRoute,
+                Query = query
+            };
+        }
+    }
+
+    public class InstancedApiMockTest
+    {
+        private string _instanceString;
+
+        public InstancedApiMockTest(string instanceString)
+        {
+            _instanceString = instanceString;
+        }
+
+        [Route("http://test/{fromRoute}")]
+        public TestResult TestMethod(string fromRoute, string query)
+        {
+            return new TestResult
+            {
+                Route = fromRoute,
+                Query = query,
+                Instance = _instanceString
+            };
+        }
+    }
+
+    public class TestResult
+    {
+        public string Instance { get; set; }
+        public string Query { get; set; }
+        public string Route { get; set; }
+    }
+}

--- a/RepairsApi.Tests/ApiMocking/MockHttpMessageHandler.cs
+++ b/RepairsApi.Tests/ApiMocking/MockHttpMessageHandler.cs
@@ -1,0 +1,158 @@
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+namespace RepairsApi.Tests.ApiMocking
+{
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly MockMessageHandlerConfig _config;
+
+        public MockHttpMessageHandler(MockMessageHandlerConfig config)
+        {
+            _config = config;
+        }
+
+        public static MockHttpMessageHandler FromClass<T>()
+            where T : class
+        {
+            return BuildMock<T>(null, true);
+        }
+
+        public static MockHttpMessageHandler FromObject<T>(T oobject)
+            where T : class
+        {
+            return BuildMock(oobject, false);
+        }
+
+        private static MockHttpMessageHandler BuildMock<T>(T oobject, bool onlyStatic)
+            where T : class
+        {
+            Type classType = typeof(T);
+
+            var config = new MockMessageHandlerConfig
+            {
+                Functions = new List<MockRouteHandler>()
+            };
+
+            config.Functions.AddRange(classType.GetMethods().Where(m => (!onlyStatic || m.IsStatic) && m.CustomAttributes.Any(attr => attr.AttributeType == typeof(RouteAttribute)))
+                .Select(method => new MockRouteHandler(method, oobject)));
+
+            return new MockHttpMessageHandler(config);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Method != HttpMethod.Get)
+            {
+                throw new Exception("Mocking Is only supported for gets at the moment");
+            }
+
+            var mockFunction = FindMockFunction(request.RequestUri);
+
+            if (mockFunction != null)
+            {
+                object result = mockFunction.Execute();
+
+                HttpResponseMessage httpResponseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+                httpResponseMessage.Content = new StringContent(JsonConvert.SerializeObject(result));
+                return Task.FromResult(httpResponseMessage);
+            }
+
+            throw new Exception("Mock Method not found");
+        }
+
+        private MockRouteHandler FindMockFunction(Uri requestUri)
+        {
+            var segments = requestUri.Segments;
+            foreach (var potentialMock in _config.Functions)
+            {
+                var segmentMatches = potentialMock.ParseSegments(segments);
+
+                if (segmentMatches)
+                {
+                    var query = HttpUtility.ParseQueryString(requestUri.Query);
+                    potentialMock.ParseQuery(query);
+                    return potentialMock;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    public class MockMessageHandlerConfig
+    {
+        public List<MockRouteHandler> Functions { get; internal set; }
+    }
+
+    public class MockRouteHandler
+    {
+        private static Regex _pathMatcher = new Regex(@"^{(.+)}\/?$");
+        private string[] _segments;
+        private readonly object _methodObject;
+        private NameValueCollection _variables;
+        private MethodInfo _method;
+
+        public MockRouteHandler(MethodInfo method, object methodObject = null)
+        {
+            if (methodObject is null && !method.IsStatic)
+            {
+                throw new Exception($"{method.Name} Either needs to be static or an instance of the object it is in needs to be passed");
+            }
+
+            _methodObject = methodObject;
+            _variables = new NameValueCollection();
+            _method = method;
+            var route = _method.GetCustomAttribute<RouteAttribute>();
+
+            var routeUri = new Uri(route.Template, UriKind.Absolute);
+            this._segments = routeUri.Segments.Select(seg => HttpUtility.UrlDecode(seg)).ToArray();
+        }
+
+        internal object Execute()
+        {
+            object[] parameters = _method.GetParameters().Select(param => _variables[param.Name]).ToArray();
+
+            return _method.Invoke(_methodObject, parameters);
+        }
+
+        internal void ParseQuery(NameValueCollection queryParams)
+        {
+            this._variables.Add(queryParams);
+        }
+
+        internal bool ParseSegments(string[] segments)
+        {
+            if (segments.Length != _segments.Length) return false;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                if (segments[i] == _segments[i])
+                {
+                    continue;
+                }
+                else if (_pathMatcher.IsMatch(_segments[i]))
+                {
+                    _variables.Add(_pathMatcher.Match(_segments[i]).Groups[1].Value, segments[i].Trim('/'));
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/RepairsApi.Tests/Helpers/HttpClientFactoryWrapper.cs
+++ b/RepairsApi.Tests/Helpers/HttpClientFactoryWrapper.cs
@@ -1,0 +1,19 @@
+using System.Net.Http;
+
+namespace RepairsApi.Tests.Helpers
+{
+    public class HttpClientFactoryWrapper : IHttpClientFactory
+    {
+        private readonly HttpClient _client;
+
+        public HttpClientFactoryWrapper(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public HttpClient CreateClient(string name)
+        {
+            return _client;
+        }
+    }
+}

--- a/RepairsApi.Tests/MockApiGateway.cs
+++ b/RepairsApi.Tests/MockApiGateway.cs
@@ -75,7 +75,7 @@ namespace RepairsApi.Tests
 
                 return _tenantApiResponse;
             }
-            
+
         }
         #endregion
 

--- a/RepairsApi.Tests/MockApiGateway.cs
+++ b/RepairsApi.Tests/MockApiGateway.cs
@@ -89,7 +89,7 @@ namespace RepairsApi.Tests
             var mock = MockHttpMessageHandler.FromClass<MockApiGateway>();
             HttpClient client = new HttpClient(mock);
             var factoryMock = new HttpClientFactoryWrapper(client);
-            
+
             _innerGateway = new ApiGateway(factoryMock);
         }
 

--- a/RepairsApi.Tests/MockApiGateway.cs
+++ b/RepairsApi.Tests/MockApiGateway.cs
@@ -74,7 +74,7 @@ namespace RepairsApi.Tests
 
                 return _tenantApiResponse;
             }
-            
+
         }
         #endregion
 

--- a/RepairsApi.Tests/MockApiGateway.cs
+++ b/RepairsApi.Tests/MockApiGateway.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
+using Moq;
 using RepairsApi.Tests.ApiMocking;
+using RepairsApi.Tests.Helpers;
 using RepairsApi.V1.Factories;
 using RepairsApi.V1.Gateways;
 using RepairsApi.V1.Gateways.Models;
@@ -86,7 +88,9 @@ namespace RepairsApi.Tests
         {
             var mock = MockHttpMessageHandler.FromClass<MockApiGateway>();
             HttpClient client = new HttpClient(mock);
-            _innerGateway = new ApiGateway(client);
+            var factoryMock = new HttpClientFactoryWrapper(client);
+            
+            _innerGateway = new ApiGateway(factoryMock);
         }
 
         public Task<ApiResponse<TResponse>> ExecuteRequest<TResponse>(Uri url) where TResponse : class

--- a/RepairsApi.Tests/MockApiGateway.cs
+++ b/RepairsApi.Tests/MockApiGateway.cs
@@ -1,3 +1,4 @@
+using RepairsApi.V1.Factories;
 using RepairsApi.V1.Gateways;
 using RepairsApi.V1.Gateways.Models;
 using System;
@@ -16,29 +17,23 @@ namespace RepairsApi.Tests
 
     public class MockApiGateway : IApiGateway
     {
-        private Dictionary<RouteMatcher, RequestHandler> _router = new Dictionary<RouteMatcher, RequestHandler>(){
-            { MatchAlerts, HandleAlerts },
-            { MatchPostCodeSearch, HandlePostCodeSearch },
-            { MatchAddressSearch, HandleAddressSearch },
-            { MatchPropertyReference, HandlePropertyReference }
-        };
+        #region Data
 
-        private static List<AlertsApiResponse> _alertsApiResponse;
-        private static List<PropertyApiResponse> _propertyApiResponse;
-
-        public static List<AlertsApiResponse> MockAlertsApiResponses
+        private static List<PropertyAlertsApiResponse> _propertyAlertsApiResponse;
+        public static List<PropertyAlertsApiResponse> MockPropertyAlertsApiResponses
         {
             get
             {
-                if (_alertsApiResponse is null)
+                if (_propertyAlertsApiResponse is null)
                 {
-                    _alertsApiResponse = new List<AlertsApiResponse>(StubAlertApiResponse().Generate(20));
+                    _propertyAlertsApiResponse = new List<PropertyAlertsApiResponse>(StubPropertyAlertApiResponse().Generate(20));
                 };
 
-                return _alertsApiResponse;
+                return _propertyAlertsApiResponse;
             }
         }
 
+        private static List<PropertyApiResponse> _propertyApiResponse;
         public static List<PropertyApiResponse> MockPropertyApiResponses
         {
             get
@@ -51,6 +46,37 @@ namespace RepairsApi.Tests
                 return _propertyApiResponse;
             }
         }
+
+        private static List<PersonAlertsApiResponse> _personAlertsApiResponse;
+        public static List<PersonAlertsApiResponse> MockPersonAlertsApiResponses
+        {
+            get
+            {
+                if (_personAlertsApiResponse is null)
+                {
+                    _personAlertsApiResponse = new List<PersonAlertsApiResponse>(StubPersonAlertApiResponse().Generate(20));
+                };
+
+                return _personAlertsApiResponse;
+            }
+        }
+
+
+        private static List<TenancyApiTenancyInformation> _tenantApiResponse;
+        public static List<TenancyApiTenancyInformation> MockTenantApiResponses
+        {
+            get
+            {
+                if (_tenantApiResponse is null)
+                {
+                    _tenantApiResponse = new List<TenancyApiTenancyInformation>(StubTenantApiResponse().Generate(40));
+                };
+
+                return _tenantApiResponse;
+            }
+            
+        }
+        #endregion
 
         public Task<ApiResponse<TResponse>> ExecuteRequest<TResponse>(Uri url) where TResponse : class
         {
@@ -78,6 +104,54 @@ namespace RepairsApi.Tests
             };
         }
 
+        #region Routing
+        private Dictionary<RouteMatcher, RequestHandler> _router = new Dictionary<RouteMatcher, RequestHandler>(){
+            { MatchTenancyInformation, HandleTenancyInformation },
+            { MatchPersonAlerts, HandlePersonAlerts },
+            { MatchPropertyAlerts, HandlePropertyAlerts },
+            { MatchPostCodeSearch, HandlePostCodeSearch },
+            { MatchAddressSearch, HandleAddressSearch },
+            { MatchPropertyReference, HandlePropertyReference }
+        };
+
+        private static ApiResponse<object> HandleTenancyInformation(string value)
+        {
+            ListTenanciesApiResponse result = new ListTenanciesApiResponse
+            {
+                Tenancies = MockTenantApiResponses.Where(tenant => tenant.PropertyReference == value).ToList()
+            };
+
+            return BuildResponse<object>(result);
+        }
+
+        private static RouteParams MatchTenancyInformation(string url)
+        {
+            return new RouteParams
+            {
+                Matches = url.Contains("testtenanciesapi"),
+                QueryValue = url.Split("=").Last()
+            };
+        }
+
+        private static RouteParams MatchPersonAlerts(string url)
+        {
+            return new RouteParams
+            {
+                Matches = url.Contains("testalertsapi") && url.Contains("people?tag_ref"),
+                QueryValue = url.Split("=").Last()
+            };
+        }
+
+        private static ApiResponse<object> HandlePersonAlerts(string value)
+        {
+            ListPersonAlertsApiResponse result = new ListPersonAlertsApiResponse
+            {
+                Contacts = MockPersonAlertsApiResponses.Where(res => res.TenancyAgreementReference == value).ToList()
+            };
+
+            return BuildResponse<object>(result);
+        }
+
         private static RouteParams MatchPostCodeSearch(string url)
         {
             return new RouteParams
@@ -96,11 +170,11 @@ namespace RepairsApi.Tests
             };
         }
 
-        private static RouteParams MatchAlerts(string url)
+        private static RouteParams MatchPropertyAlerts(string url)
         {
             return new RouteParams
             {
-                Matches = url.Contains("testalertsapi"),
+                Matches = url.Contains("testalertsapi") && url.Contains("properties"),
                 QueryValue = url.Split("/").Last()
             };
         }
@@ -120,10 +194,11 @@ namespace RepairsApi.Tests
             return BuildResponse<object>(MockPropertyApiResponses.Where(prop => prop.Address1.Contains(value)).ToList());
         }
 
-        private static ApiResponse<object> HandleAlerts(string value)
+        private static ApiResponse<object> HandlePropertyAlerts(string value)
         {
-            return BuildResponse<object>(MockAlertsApiResponses.Where(res => res.PropertyReference == value).FirstOrDefault());
+            return BuildResponse<object>(MockPropertyAlertsApiResponses.Where(res => res.PropertyReference == value).FirstOrDefault());
         }
+        #endregion
 
         internal static void AddProperties(int count, string postcode = null, string address = null)
         {
@@ -140,6 +215,39 @@ namespace RepairsApi.Tests
             }
 
             MockPropertyApiResponses.AddRange(newProperties);
+        }
+
+        internal static PropertyApiResponse NewProperty()
+        {
+            var newProperty = StubPropertyApiResponse().Generate();
+
+            MockPropertyApiResponses.Add(newProperty);
+
+            return newProperty;
+        }
+
+        internal static void AddPropertyAlerts(int count, string propRef)
+        {
+            PropertyAlertsApiResponse mockAlerts = StubPropertyAlertApiResponse(count, propRef).Generate();
+            MockPropertyAlertsApiResponses.Add(mockAlerts);
+        }
+
+        internal static void AddTenantInformation(string tenantReference, string propRef, bool canRaiseRepair = false)
+        {
+            string code = canRaiseRepair ? ApiModelFactory.RaisableTenureCodes.First() : "not a valid code";
+            MockTenantApiResponses.Add(new TenancyApiTenancyInformation
+            {
+                TenancyAgreementReference = tenantReference,
+                PropertyReference = propRef,
+                TenureType = $"{code}: Rnadom descirption"
+            });
+        }
+
+        internal static void AddPersonAlerts(int count, string tenantReferance)
+        {
+            PersonAlertsApiResponse mockAlerts = StubPersonAlertApiResponse(count, tenantReferance).Generate();
+
+            MockPersonAlertsApiResponses.Add(mockAlerts);
         }
 
         private static ApiResponse<T> BuildResponse<T>(T content) where T : class

--- a/RepairsApi.Tests/RepairsApi.Tests.csproj
+++ b/RepairsApi.Tests/RepairsApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
 

--- a/RepairsApi.Tests/V1/Controllers/PropertiesControllerTests.cs
+++ b/RepairsApi.Tests/V1/Controllers/PropertiesControllerTests.cs
@@ -58,7 +58,8 @@ namespace RepairsApi.Tests.V1.Controllers
             var property = new PropertyWithAlerts()
             {
                 PropertyModel = StubProperties().Generate(),
-                Alerts = StubAlerts().Generate(5)
+                PersonAlerts = StubAlerts().Generate(5),
+                LocationAlerts = StubAlerts().Generate(5)
             };
             property.PropertyModel.PropertyReference = expectedPropertyReference;
 
@@ -90,13 +91,19 @@ namespace RepairsApi.Tests.V1.Controllers
             statusCode.Should().Be(404);
         }
 
-        [TestCase(0)]
-        [TestCase(5)]
-        public async Task ListsAlerts(int alertCount)
+        [TestCase(0, 0)]
+        [TestCase(5, 0)]
+        [TestCase(0, 6)]
+        [TestCase(8, 7)]
+        public async Task ListsAlerts(int propertyAlertCount, int personAlertCount)
         {
             // Arrange
             string expectedPropertyReference = new Faker().Random.Number().ToString();
-            PropertyAlertList alertList = StubAlertList(expectedPropertyReference, alertCount);
+            AlertList alertList = new AlertList
+            {
+                PropertyAlerts = StubPropertyAlertList(expectedPropertyReference, propertyAlertCount),
+                PersonAlerts = new PersonAlertList { Alerts = StubAlerts().Generate(personAlertCount) }
+            };
 
             _listAlertsUseCaseMock.Setup(m => m.ExecuteAsync(It.IsAny<string>())).ReturnsAsync(alertList);
 
@@ -107,7 +114,8 @@ namespace RepairsApi.Tests.V1.Controllers
 
             // Assert
             statusCode.Should().Be(200);
-            alertResult.Alerts.Should().HaveCount(alertCount);
+            alertResult.LocationAlert.Should().HaveCount(propertyAlertCount);
+            alertResult.PersonAlert.Should().HaveCount(personAlertCount);
             alertResult.PropertyReference.Should().Be(expectedPropertyReference);
         }
 

--- a/RepairsApi.Tests/V1/DataFakers.cs
+++ b/RepairsApi.Tests/V1/DataFakers.cs
@@ -2,6 +2,7 @@ using Bogus;
 using RepairsApi.V1.Domain;
 using RepairsApi.V1.Factories;
 using RepairsApi.V1.Gateways.Models;
+using System.Linq;
 
 namespace RepairsApi.Tests.V1
 {
@@ -44,7 +45,7 @@ namespace RepairsApi.Tests.V1
                 .RuleFor(a => a.AddressLine, f => f.Random.String());
         }
 
-        public static PropertyAlertList StubAlertList(string expectedPropertyReference, int alertCount)
+        public static PropertyAlertList StubPropertyAlertList(string expectedPropertyReference, int alertCount)
         {
             return new PropertyAlertList
             {
@@ -53,7 +54,7 @@ namespace RepairsApi.Tests.V1
             };
         }
 
-        public static Faker<AlertsApiResponse> StubAlertApiResponse(int? alertCount = null, string propertyReference = null)
+        public static Faker<PropertyAlertsApiResponse> StubPropertyAlertApiResponse(int? alertCount = null, string propertyReference = null)
         {
             Faker<AlertApiAlertViewModel> alertsFake = new Faker<AlertApiAlertViewModel>()
                 .RuleFor(pa => pa.AlertCode, f => f.Random.String2(0, 100))
@@ -61,8 +62,21 @@ namespace RepairsApi.Tests.V1
                 .RuleFor(pa => pa.StartDate, f => f.Random.String2(0, 100))
                 .RuleFor(pa => pa.EndDate, f => f.Random.String2(0, 100));
 
-            return new Faker<AlertsApiResponse>()
+            return new Faker<PropertyAlertsApiResponse>()
                 .RuleFor(res => res.PropertyReference, f => propertyReference ?? f.Random.Int().ToString())
+                .RuleFor(res => res.Alerts, f => alertsFake.Generate(alertCount ?? f.Random.Int(0, 20)));
+        }
+
+        public static Faker<PersonAlertsApiResponse> StubPersonAlertApiResponse(int? alertCount = null, string tenancyAgreementReference = null)
+        {
+            Faker<AlertApiAlertViewModel> alertsFake = new Faker<AlertApiAlertViewModel>()
+                .RuleFor(pa => pa.AlertCode, f => f.Random.String2(0, 100))
+                .RuleFor(pa => pa.Description, f => f.Random.String2(0, 100))
+                .RuleFor(pa => pa.StartDate, f => f.Random.String2(0, 100))
+                .RuleFor(pa => pa.EndDate, f => f.Random.String2(0, 100));
+
+            return new Faker<PersonAlertsApiResponse>()
+                .RuleFor(res => res.TenancyAgreementReference, f => tenancyAgreementReference ?? f.Random.Int().ToString())
                 .RuleFor(res => res.Alerts, f => alertsFake.Generate(alertCount ?? f.Random.Int(0, 20)));
         }
 
@@ -74,6 +88,17 @@ namespace RepairsApi.Tests.V1
                 .RuleFor(res => res.LevelCode, f => f.Random.String2(0, 100))
                 .RuleFor(res => res.PropRef, f => f.Random.Int().ToString())
                 .RuleFor(res => res.SubtypCode, f => f.PickRandom<string>(ApiModelFactory.HierarchyDescriptions.Keys));
+        }
+
+        public static Faker<TenancyApiTenancyInformation> StubTenantApiResponse()
+        {
+            return new Faker<TenancyApiTenancyInformation>()
+                .RuleFor(res => res.TenancyAgreementReference, f => f.Random.Int().ToString())
+                .RuleFor(res => res.TenureType, f =>
+                {
+                    string code = f.Random.Bool() ? f.PickRandom(ApiModelFactory.RaisableTenureCodes.AsEnumerable()) : f.Random.String2(3);
+                    return $"{code}: {f.Random.Words(10)}";
+                });
         }
     }
 }

--- a/RepairsApi.Tests/V1/DataFakers.cs
+++ b/RepairsApi.Tests/V1/DataFakers.cs
@@ -7,9 +7,9 @@ namespace RepairsApi.Tests.V1
 {
     public static class DataFakers
     {
-        public static Faker<PropertyAlert> StubAlerts()
+        public static Faker<Alert> StubAlerts()
         {
-            return new Faker<PropertyAlert>()
+            return new Faker<Alert>()
                 .RuleFor(pa => pa.AlertCode, f => f.Random.String())
                 .RuleFor(pa => pa.Description, f => f.Random.String())
                 .RuleFor(pa => pa.StartDate, f => f.Random.String())

--- a/RepairsApi.Tests/V1/E2ETests/PropertyApitests.cs
+++ b/RepairsApi.Tests/V1/E2ETests/PropertyApitests.cs
@@ -1,6 +1,7 @@
 using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
+using RepairsApi.Tests.Helpers;
 using RepairsApi.V1.Boundary.Response;
 using RepairsApi.V1.Domain;
 using RepairsApi.V1.Factories;
@@ -31,7 +32,7 @@ namespace RepairsApi.Tests.V1.E2ETests
 
             PropertyViewModel expectedResponse = expectedProperty.ToDomain().ToResponse();
 
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
 
             // Act
             var response = client.ExecuteRequest<PropertyResponse>(new Uri($"/api/v2/properties/{expectedProperty.PropRef}", UriKind.Relative)).Result;
@@ -50,7 +51,7 @@ namespace RepairsApi.Tests.V1.E2ETests
         public void Returns404WhenPropertDoesntExist()
         {
             // Arrange
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
             string dummyReference = "dummyReference";
 
             // Act
@@ -75,7 +76,7 @@ namespace RepairsApi.Tests.V1.E2ETests
             MockApiGateway.AddTenantInformation(tenantReference, expectedProperty.PropRef);
             MockApiGateway.AddPersonAlerts(expectedPersonAlertCount, tenantReference);
 
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
 
             // Act
             var response = client.ExecuteRequest<CautionaryAlertResponseList>(new Uri($"/api/v2/properties/{expectedProperty.PropRef}/alerts", UriKind.Relative)).Result;
@@ -94,7 +95,7 @@ namespace RepairsApi.Tests.V1.E2ETests
             // Arrange
             const string Postcode = "AA11AA";
             MockApiGateway.AddProperties(5, postcode: Postcode);
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
 
             // Act
             var response = client.ExecuteRequest<List<PropertyViewModel>>(new Uri($"/api/v2/properties/?postcode={Postcode}", UriKind.Relative)).Result;
@@ -111,7 +112,7 @@ namespace RepairsApi.Tests.V1.E2ETests
             // Arrange
             const string Address = "1 road street";
             MockApiGateway.AddProperties(7, address: Address);
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
 
             // Act
             var response = client.ExecuteRequest<List<PropertyViewModel>>(new Uri($"/api/v2/properties/?address={Address}", UriKind.Relative)).Result;
@@ -128,7 +129,7 @@ namespace RepairsApi.Tests.V1.E2ETests
             // Arrange
             const string Address = "2 lane way street";
             MockApiGateway.AddProperties(7, address: Address);
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
 
             // Act
             var response = client.ExecuteRequest<List<PropertyViewModel>>(new Uri($"/api/v2/properties/?q={Address}", UriKind.Relative)).Result;
@@ -145,7 +146,7 @@ namespace RepairsApi.Tests.V1.E2ETests
             // Arrange
             const string Postcode = "BB22BB";
             MockApiGateway.AddProperties(5, postcode: Postcode);
-            ApiGateway client = new ApiGateway(Client);
+            ApiGateway client = new ApiGateway(new HttpClientFactoryWrapper(Client));
 
             // Act
             var response = client.ExecuteRequest<List<PropertyViewModel>>(new Uri($"/api/v2/properties/?q={Postcode}", UriKind.Relative)).Result;

--- a/RepairsApi.Tests/V1/Gateways/AlertGatewayTests.cs
+++ b/RepairsApi.Tests/V1/Gateways/AlertGatewayTests.cs
@@ -35,11 +35,11 @@ namespace RepairsApi.Tests.V1.Gateways
         }
 
         [Test]
-        public async Task SendsRequest()
+        public async Task GetsPropertyAlerts()
         {
             // Arrange
-            var stubData = BuildResponse(StubAlertApiResponse(5).Generate());
-            _apiGatewayMock.Setup(gw => gw.ExecuteRequest<AlertsApiResponse>(It.IsAny<Uri>())).ReturnsAsync(stubData);
+            var stubData = BuildResponse(StubPropertyAlertApiResponse(5).Generate());
+            _apiGatewayMock.Setup(gw => gw.ExecuteRequest<PropertyAlertsApiResponse>(It.IsAny<Uri>())).ReturnsAsync(stubData);
 
             // Act
             var result = await _classUnderTest.GetLocationAlertsAsync("");
@@ -50,11 +50,11 @@ namespace RepairsApi.Tests.V1.Gateways
         }
 
         [Test]
-        public async Task ReturnEmptyListWhen404()
+        public async Task ReturnEmptyPropertyAlertsWhen404()
         {
             // Arrange
-            var stubData = BuildResponse<AlertsApiResponse>(null);
-            _apiGatewayMock.Setup(gw => gw.ExecuteRequest<AlertsApiResponse>(It.IsAny<Uri>())).ReturnsAsync(stubData);
+            var stubData = BuildResponse<PropertyAlertsApiResponse>(null);
+            _apiGatewayMock.Setup(gw => gw.ExecuteRequest<PropertyAlertsApiResponse>(It.IsAny<Uri>())).ReturnsAsync(stubData);
             const string expectedPropertyReference = "";
 
             // Act
@@ -63,6 +63,33 @@ namespace RepairsApi.Tests.V1.Gateways
             // Assert
             result.PropertyReference.Should().Be(expectedPropertyReference);
             result.Alerts.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task ReturnEmptyListWhenNullTenancyReference()
+        {
+            // Act
+            var result = await _classUnderTest.GetPersonAlertsAsync(null);
+
+            // Assert
+            result.Alerts.Should().BeEmpty();
+        }
+
+        [TestCase(10)]
+        [TestCase(4)]
+        [TestCase(0)]
+        public async Task ReturnPersonAlertList(int expectedAlertCount)
+        {
+            // Arrange
+            var stubData = BuildResponse(new ListPersonAlertsApiResponse { Contacts = StubPersonAlertApiResponse(expectedAlertCount).Generate(1) });
+            _apiGatewayMock.Setup(gw => gw.ExecuteRequest<ListPersonAlertsApiResponse>(It.IsAny<Uri>())).ReturnsAsync(stubData);
+            const string expectedPropertyReference = "";
+
+            // Act
+            var result = await _classUnderTest.GetPersonAlertsAsync(expectedPropertyReference);
+
+            // Assert
+            result.Alerts.Should().HaveCount(expectedAlertCount);
         }
 
         private static ApiResponse<T> BuildResponse<T>(T content) where T : class

--- a/RepairsApi.Tests/V1/Gateways/AlertGatewayTests.cs
+++ b/RepairsApi.Tests/V1/Gateways/AlertGatewayTests.cs
@@ -42,7 +42,7 @@ namespace RepairsApi.Tests.V1.Gateways
             _apiGatewayMock.Setup(gw => gw.ExecuteRequest<AlertsApiResponse>(It.IsAny<Uri>())).ReturnsAsync(stubData);
 
             // Act
-            var result = await _classUnderTest.GetAlertsAsync("");
+            var result = await _classUnderTest.GetLocationAlertsAsync("");
 
             // Assert
             result.PropertyReference.Should().Be(stubData.Content.PropertyReference);
@@ -58,7 +58,7 @@ namespace RepairsApi.Tests.V1.Gateways
             const string expectedPropertyReference = "";
 
             // Act
-            var result = await _classUnderTest.GetAlertsAsync(expectedPropertyReference);
+            var result = await _classUnderTest.GetLocationAlertsAsync(expectedPropertyReference);
 
             // Assert
             result.PropertyReference.Should().Be(expectedPropertyReference);

--- a/RepairsApi.Tests/V1/Gateways/ApiGatewayTests.cs
+++ b/RepairsApi.Tests/V1/Gateways/ApiGatewayTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using RepairsApi.Tests.Helpers;
 using RepairsApi.V1.Gateways;
 using System;
 using System.Diagnostics.CodeAnalysis;
@@ -49,7 +50,7 @@ namespace RepairsApi.Tests.V1.Gateways
                .ReturnsAsync(response);
 
             var httpClient = new HttpClient(handlerMock.Object);
-            return new ApiGateway(httpClient);
+            return new ApiGateway(new HttpClientFactoryWrapper(httpClient));
         }
     }
 

--- a/RepairsApi.Tests/V1/UseCase/GetPropertyUseCaseTests.cs
+++ b/RepairsApi.Tests/V1/UseCase/GetPropertyUseCaseTests.cs
@@ -30,16 +30,16 @@ namespace RepairsApi.Tests.V1.UseCase
         {
             // Arrange
             var expectedProperty = StubProperties().Generate();
-            var expectedAlerts = StubAlertList(expectedProperty.PropertyReference, 5);
+            var expectedLocationAlerts = StubAlertList(expectedProperty.PropertyReference, 5);
             _propertyGatewayMock.Setup(gm => gm.GetByReferenceAsync(It.IsAny<string>())).ReturnsAsync(expectedProperty);
-            _alertGatewayMock.Setup(gm => gm.GetAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedAlerts);
+            _alertGatewayMock.Setup(gm => gm.GetLocationAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedLocationAlerts);
 
             // Act
             var result = await _classUnderTest.ExecuteAsync(expectedProperty.PropertyReference);
 
             // Assert
             result.PropertyModel.Should().Be(expectedProperty);
-            result.Alerts.Should().BeEquivalentTo(expectedAlerts.Alerts);
+            result.LocationAlerts.Should().BeEquivalentTo(expectedLocationAlerts.Alerts);
         }
 
         [Test]

--- a/RepairsApi.Tests/V1/UseCase/GetPropertyUseCaseTests.cs
+++ b/RepairsApi.Tests/V1/UseCase/GetPropertyUseCaseTests.cs
@@ -15,6 +15,7 @@ namespace RepairsApi.Tests.V1.UseCase
     {
         private Mock<IPropertyGateway> _propertyGatewayMock;
         private Mock<IAlertsGateway> _alertGatewayMock;
+        private Mock<ITenancyGateway> _tenantGatewayMock;
         private GetPropertyUseCase _classUnderTest;
 
         [SetUp]
@@ -22,7 +23,8 @@ namespace RepairsApi.Tests.V1.UseCase
         {
             _propertyGatewayMock = new Mock<IPropertyGateway>();
             _alertGatewayMock = new Mock<IAlertsGateway>();
-            _classUnderTest = new GetPropertyUseCase(_propertyGatewayMock.Object, _alertGatewayMock.Object);
+            _tenantGatewayMock = new Mock<ITenancyGateway>();
+            _classUnderTest = new GetPropertyUseCase(_propertyGatewayMock.Object, _alertGatewayMock.Object, _tenantGatewayMock.Object);
         }
 
         [Test]
@@ -30,9 +32,11 @@ namespace RepairsApi.Tests.V1.UseCase
         {
             // Arrange
             var expectedProperty = StubProperties().Generate();
-            var expectedLocationAlerts = StubAlertList(expectedProperty.PropertyReference, 5);
+            var expectedLocationAlerts = StubPropertyAlertList(expectedProperty.PropertyReference, 5);
+            var expectedPersonAlerts = new PersonAlertList() { Alerts = StubAlerts().Generate(5) };
             _propertyGatewayMock.Setup(gm => gm.GetByReferenceAsync(It.IsAny<string>())).ReturnsAsync(expectedProperty);
             _alertGatewayMock.Setup(gm => gm.GetLocationAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedLocationAlerts);
+            _alertGatewayMock.Setup(gm => gm.GetPersonAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedPersonAlerts);
 
             // Act
             var result = await _classUnderTest.ExecuteAsync(expectedProperty.PropertyReference);
@@ -40,6 +44,7 @@ namespace RepairsApi.Tests.V1.UseCase
             // Assert
             result.PropertyModel.Should().Be(expectedProperty);
             result.LocationAlerts.Should().BeEquivalentTo(expectedLocationAlerts.Alerts);
+            result.PersonAlerts.Should().BeEquivalentTo(expectedPersonAlerts.Alerts);
         }
 
         [Test]

--- a/RepairsApi.Tests/V1/UseCase/ListAlertsUseCaseTests.cs
+++ b/RepairsApi.Tests/V1/UseCase/ListAlertsUseCaseTests.cs
@@ -2,6 +2,7 @@ using Bogus;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using RepairsApi.V1.Domain;
 using RepairsApi.V1.Gateways;
 using RepairsApi.V1.UseCase;
 using System.Threading.Tasks;
@@ -14,30 +15,36 @@ namespace RepairsApi.Tests.V1.UseCase
     public class ListAlertsUseCaseTests
     {
         private Mock<IAlertsGateway> _alertGatewayMock;
+        private Mock<ITenancyGateway> _tenancyGatewayMock;
         private ListAlertsUseCase _classUnderTest;
 
         [SetUp]
         public void Setup()
         {
             _alertGatewayMock = new Mock<IAlertsGateway>();
-            _classUnderTest = new ListAlertsUseCase(_alertGatewayMock.Object);
+            _tenancyGatewayMock = new Mock<ITenancyGateway>();
+            _classUnderTest = new ListAlertsUseCase(_alertGatewayMock.Object, _tenancyGatewayMock.Object);
         }
 
         [Test]
         public async Task ReturnsAlerts()
         {
             // Arrange
-            const int expectedAlertCount = 5;
+            const int expectedPropertyAlertCount = 5;
+            const int expectedPersonAlertCount = 5;
             string expectedPropertyReference = new Faker().Random.Number().ToString();
-            var expectedAlertList = StubAlertList(expectedPropertyReference, expectedAlertCount);
-            _alertGatewayMock.Setup(gm => gm.GetLocationAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedAlertList);
+            var expectedPropertyAlertList = StubPropertyAlertList(expectedPropertyReference, expectedPropertyAlertCount);
+            var expectedPersonAlertList = new PersonAlertList { Alerts = StubAlerts().Generate(expectedPersonAlertCount) };
+            _alertGatewayMock.Setup(gm => gm.GetLocationAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedPropertyAlertList);
+            _alertGatewayMock.Setup(gm => gm.GetPersonAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedPersonAlertList);
 
             // Act
             var result = await _classUnderTest.ExecuteAsync(expectedPropertyReference);
 
             // Assert
-            result.PropertyReference.Should().Be(expectedPropertyReference);
-            result.Alerts.Should().HaveCount(expectedAlertCount);
+            result.PropertyAlerts.PropertyReference.Should().Be(expectedPropertyReference);
+            result.PropertyAlerts.Alerts.Should().HaveCount(expectedPropertyAlertCount);
+            result.PersonAlerts.Alerts.Should().HaveCount(expectedPersonAlertCount);
         }
     }
 }

--- a/RepairsApi.Tests/V1/UseCase/ListAlertsUseCaseTests.cs
+++ b/RepairsApi.Tests/V1/UseCase/ListAlertsUseCaseTests.cs
@@ -30,7 +30,7 @@ namespace RepairsApi.Tests.V1.UseCase
             const int expectedAlertCount = 5;
             string expectedPropertyReference = new Faker().Random.Number().ToString();
             var expectedAlertList = StubAlertList(expectedPropertyReference, expectedAlertCount);
-            _alertGatewayMock.Setup(gm => gm.GetAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedAlertList);
+            _alertGatewayMock.Setup(gm => gm.GetLocationAlertsAsync(It.IsAny<string>())).ReturnsAsync(expectedAlertList);
 
             // Act
             var result = await _classUnderTest.ExecuteAsync(expectedPropertyReference);

--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -116,6 +116,7 @@ namespace RepairsApi
             services.TryAddTransient<IApiGateway, ApiGateway>();
             services.AddTransient<IPropertyGateway, PropertyGateway>();
             services.AddTransient<IAlertsGateway, AlertsGateway>();
+            services.AddTransient<ITenancyGateway, TenancyGateway>();
         }
 
         private static void ConfigureDbContext(IServiceCollection services)

--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -107,6 +107,7 @@ namespace RepairsApi
             });
             ConfigureDbContext(services);
 
+            services.AddHttpClient();
             services.Configure<GatewayOptions>(Configuration.GetSection(nameof(GatewayOptions)));
 
             services.AddTransient<IListAlertsUseCase, ListAlertsUseCase>();

--- a/RepairsApi/V1/Boundary/Response/AlertsViewModel.cs
+++ b/RepairsApi/V1/Boundary/Response/AlertsViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace RepairsApi.V1.Boundary.Response
+{
+    public class AlertsViewModel
+    {
+        public List<CautionaryAlertViewModel> LocationAlert { get; set; }
+        public List<CautionaryAlertViewModel> PersonAlert { get; set; }
+    }
+}

--- a/RepairsApi/V1/Boundary/Response/CautionaryAlertResponseList.cs
+++ b/RepairsApi/V1/Boundary/Response/CautionaryAlertResponseList.cs
@@ -10,8 +10,13 @@ namespace RepairsApi.V1.Boundary.Response
         public string PropertyReference { get; set; }
 
         /// <summary>
-        /// Gets or Sets Alerts
+        /// Gets or Sets Location Alerts
         /// </summary>
-        public List<CautionaryAlertViewModel> Alerts { get; set; }
+        public List<CautionaryAlertViewModel> LocationAlert { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Person Alerts
+        /// </summary>
+        public List<CautionaryAlertViewModel> PersonAlert { get; set; }
     }
 }

--- a/RepairsApi/V1/Boundary/Response/CautionaryAlertViewModel.cs
+++ b/RepairsApi/V1/Boundary/Response/CautionaryAlertViewModel.cs
@@ -5,12 +5,12 @@ namespace RepairsApi.V1.Boundary.Response
         /// <summary>
         /// Gets or Sets AlertCode
         /// </summary>
-        public string AlertCode { get; set; }
+        public string Type { get; set; }
 
         /// <summary>
         /// Gets or Sets Description
         /// </summary>
-        public string Description { get; set; }
+        public string Comments { get; set; }
 
         /// <summary>
         /// Gets or Sets StartDate

--- a/RepairsApi/V1/Boundary/Response/PropertyResponse.cs
+++ b/RepairsApi/V1/Boundary/Response/PropertyResponse.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace RepairsApi.V1.Boundary.Response
 {
     public class PropertyResponse
@@ -12,6 +10,11 @@ namespace RepairsApi.V1.Boundary.Response
         /// <summary>
         /// Gets or Sets CautionaryAlerts
         /// </summary>
-        public List<CautionaryAlertViewModel> CautionaryAlerts { get; set; }
+        public AlertsViewModel Alerts { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Tenure Information
+        /// </summary>
+        public TenureViewModel Tenure { get; set; }
     }
 }

--- a/RepairsApi/V1/Boundary/Response/TenureViewModel.cs
+++ b/RepairsApi/V1/Boundary/Response/TenureViewModel.cs
@@ -1,0 +1,20 @@
+namespace RepairsApi.V1.Boundary.Response
+{
+    public class TenureViewModel
+    {
+        /// <summary>
+        /// Gets or Sets Typecode
+        /// </summary>
+        public string TypeCode { get; set; }
+
+        /// <summary>
+        /// Gets or Sets TypeDescription
+        /// </summary>
+        public string TypeDescription { get; set; }
+
+        /// <summary>
+        /// Gets or Sets CanRaiseRepair
+        /// </summary>
+        public bool CanRaiseRepair { get; set; }
+    }
+}

--- a/RepairsApi/V1/Controllers/PropertiesController.cs
+++ b/RepairsApi/V1/Controllers/PropertiesController.cs
@@ -81,7 +81,7 @@ namespace RepairsApi.V1.Controllers
         [Route("{propertyReference}/alerts")]
         public async Task<IActionResult> ListCautionaryAlerts([FromRoute][Required] string propertyReference)
         {
-            PropertyAlertList alerts = await _listAlertsUseCase.ExecuteAsync(propertyReference);
+            AlertList alerts = await _listAlertsUseCase.ExecuteAsync(propertyReference);
 
             return Ok(alerts.ToResponse());
         }

--- a/RepairsApi/V1/Domain/Alert.cs
+++ b/RepairsApi/V1/Domain/Alert.cs
@@ -1,6 +1,6 @@
 namespace RepairsApi.V1.Domain
 {
-    public class PropertyAlert
+    public class Alert
     {
         public string AlertCode { get; set; }
         public string Description { get; set; }

--- a/RepairsApi/V1/Domain/AlertList.cs
+++ b/RepairsApi/V1/Domain/AlertList.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace RepairsApi.V1.Domain
 {
     public class AlertList

--- a/RepairsApi/V1/Domain/AlertList.cs
+++ b/RepairsApi/V1/Domain/AlertList.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RepairsApi.V1.Domain
+{
+    public class AlertList
+    {
+        public PropertyAlertList PropertyAlerts { get; set; }
+        public PersonAlertList PersonAlerts { get; set; }
+    }
+}

--- a/RepairsApi/V1/Domain/PersonAlertList.cs
+++ b/RepairsApi/V1/Domain/PersonAlertList.cs
@@ -2,9 +2,8 @@ using System.Collections.Generic;
 
 namespace RepairsApi.V1.Domain
 {
-    public class PropertyAlertList
+    public class PersonAlertList
     {
-        public string PropertyReference { get; set; }
         public IEnumerable<Alert> Alerts { get; set; }
     }
 }

--- a/RepairsApi/V1/Domain/PropertyWithAlerts.cs
+++ b/RepairsApi/V1/Domain/PropertyWithAlerts.cs
@@ -5,6 +5,8 @@ namespace RepairsApi.V1.Domain
     public class PropertyWithAlerts
     {
         public PropertyModel PropertyModel { get; set; }
-        public IEnumerable<PropertyAlert> Alerts { get; set; }
+        public IEnumerable<Alert> LocationAlerts { get; set; }
+        public IEnumerable<Alert> PersonAlerts { get; set; }
+        public TenureInformation Tenure { get; set; }
     }
 }

--- a/RepairsApi/V1/Domain/TenureInformation.cs
+++ b/RepairsApi/V1/Domain/TenureInformation.cs
@@ -2,6 +2,7 @@ namespace RepairsApi.V1.Domain
 {
     public class TenureInformation
     {
+        public string TenancyAgreementReference { get; set; }
         public string TypeDescription { get; set; }
         public string TypeCode { get; set; }
         public bool CanRaiseRepair { get; set; }

--- a/RepairsApi/V1/Domain/TenureInformation.cs
+++ b/RepairsApi/V1/Domain/TenureInformation.cs
@@ -1,0 +1,9 @@
+namespace RepairsApi.V1.Domain
+{
+    public class TenureInformation
+    {
+        public string TypeDescription { get; set; }
+        public string TypeCode { get; set; }
+        public bool CanRaiseRepair { get; set; }
+    }
+}

--- a/RepairsApi/V1/Factories/ApiModelFactory.cs
+++ b/RepairsApi/V1/Factories/ApiModelFactory.cs
@@ -37,15 +37,20 @@ namespace RepairsApi.V1.Factories
             return new PropertyAlertList
             {
                 PropertyReference = apiResponse.PropertyReference,
-                Alerts = apiResponse.Alerts.Select(alertResponse => alertResponse.ToDomain())
+                Alerts = apiResponse.Alerts.ToDomain()
             };
         }
 
-        public static PropertyAlert ToDomain(this AlertApiAlertViewModel apiResponse)
+        public static IEnumerable<Alert> ToDomain(this IEnumerable<AlertApiAlertViewModel> apiResponse)
+        {
+            return apiResponse.Select(alertResponse => alertResponse.ToDomain());
+        }
+
+        public static Alert ToDomain(this AlertApiAlertViewModel apiResponse)
         {
             if (apiResponse is null) return null;
 
-            return new PropertyAlert
+            return new Alert
             {
                 AlertCode = apiResponse.AlertCode,
                 Description = apiResponse.Description,

--- a/RepairsApi/V1/Factories/ApiModelFactory.cs
+++ b/RepairsApi/V1/Factories/ApiModelFactory.cs
@@ -127,7 +127,7 @@ namespace RepairsApi.V1.Factories
 
         public static TenureInformation ToDomain(this ListTenanciesApiResponse apiResponse)
         {
-            TenancyApiTenancyInformation tenancyInformation = apiResponse.Tenancies.FirstOrDefault();
+            TenancyApiTenancyInformation tenancyInformation = apiResponse?.Tenancies.FirstOrDefault();
 
             if (tenancyInformation == null) return null;
 

--- a/RepairsApi/V1/Factories/ApiModelFactory.cs
+++ b/RepairsApi/V1/Factories/ApiModelFactory.cs
@@ -30,7 +30,22 @@ namespace RepairsApi.V1.Factories
             {"WLK", "Walk-Up Block" }
         };
 
-        public static PropertyAlertList ToDomain(this AlertsApiResponse apiResponse)
+        public static HashSet<string> RaisableTenureCodes => new HashSet<string>
+        {
+            "ASY",
+            "COM",
+            "DEC",
+            "INT",
+            "MPA",
+            "NON",
+            "PVG",
+            "SEC",
+            "TAF",
+            "TGA",
+            "TRA"
+        };
+
+        public static PropertyAlertList ToDomain(this PropertyAlertsApiResponse apiResponse)
         {
             if (apiResponse is null) return null;
 
@@ -97,6 +112,32 @@ namespace RepairsApi.V1.Factories
                 LevelCode = apiResponse.LevelCode,
                 SubTypeCode = apiResponse.SubtypCode,
                 SubTypeDescription = HierarchyDescriptions[apiResponse.SubtypCode]
+            };
+        }
+
+        public static PersonAlertList ToDomain(this ListPersonAlertsApiResponse apiResponse)
+        {
+            if (apiResponse is null) return null;
+
+            return new PersonAlertList
+            {
+                Alerts = apiResponse.Contacts.First().Alerts.ToDomain()
+            };
+        }
+
+        public static TenureInformation ToDomain(this ListTenanciesApiResponse apiResponse)
+        {
+            TenancyApiTenancyInformation tenancyInformation = apiResponse.Tenancies.FirstOrDefault();
+
+            if (tenancyInformation == null) return null;
+
+            string[] splitTenureType = tenancyInformation.TenureType.Split(": ");
+            return new TenureInformation
+            {
+                TenancyAgreementReference = tenancyInformation.TenancyAgreementReference,
+                TypeCode = splitTenureType.First(),
+                TypeDescription = splitTenureType.Last(),
+                CanRaiseRepair = RaisableTenureCodes.Contains(splitTenureType.First())
             };
         }
     }

--- a/RepairsApi/V1/Factories/ResponseFactory.cs
+++ b/RepairsApi/V1/Factories/ResponseFactory.cs
@@ -77,6 +77,8 @@ namespace RepairsApi.V1.Factories
 
         public static TenureViewModel ToResponse(this TenureInformation domain)
         {
+            if (domain == null) return null;
+
             return new TenureViewModel
             {
                 CanRaiseRepair = domain.CanRaiseRepair,

--- a/RepairsApi/V1/Factories/ResponseFactory.cs
+++ b/RepairsApi/V1/Factories/ResponseFactory.cs
@@ -89,6 +89,8 @@ namespace RepairsApi.V1.Factories
 
         public static List<PropertyViewModel> ToResponse(this IEnumerable<PropertyModel> domainList)
         {
+            if (domainList == null) return new List<PropertyViewModel>();
+
             return domainList.Select(domain => domain.ToResponse()).ToList();
         }
     }

--- a/RepairsApi/V1/Factories/ResponseFactory.cs
+++ b/RepairsApi/V1/Factories/ResponseFactory.cs
@@ -8,21 +8,22 @@ namespace RepairsApi.V1.Factories
 {
     public static class ResponseFactory
     {
-        public static CautionaryAlertResponseList ToResponse(this PropertyAlertList domain)
+        public static CautionaryAlertResponseList ToResponse(this AlertList domain)
         {
             return new CautionaryAlertResponseList()
             {
-                PropertyReference = domain.PropertyReference,
-                Alerts = domain.Alerts.Select(alert => alert.ToResponse()).ToList()
+                PropertyReference = domain.PropertyAlerts.PropertyReference,
+                LocationAlert = domain.PropertyAlerts.Alerts.Select(alert => alert.ToResponse()).ToList(),
+                PersonAlert = domain.PersonAlerts.Alerts.Select(alert => alert.ToResponse()).ToList()
             };
         }
 
-        public static CautionaryAlertViewModel ToResponse(this PropertyAlert domain)
+        public static CautionaryAlertViewModel ToResponse(this Alert domain)
         {
             return new CautionaryAlertViewModel
             {
-                AlertCode = domain.AlertCode,
-                Description = domain.Description,
+                Type = domain.AlertCode,
+                Comments = domain.Description,
                 EndDate = domain.EndDate,
                 StartDate = domain.StartDate
             };
@@ -64,7 +65,23 @@ namespace RepairsApi.V1.Factories
             return new PropertyResponse
             {
                 Property = domain.PropertyModel.ToResponse(),
-                CautionaryAlerts = domain.Alerts.Select(alert => alert.ToResponse()).ToList()
+                Alerts = new AlertsViewModel
+                {
+                    LocationAlert = domain.LocationAlerts.Select(alert => alert.ToResponse()).ToList(),
+                    PersonAlert = domain.PersonAlerts.Select(alert => alert.ToResponse()).ToList(),
+                },
+                Tenure = domain.Tenure.ToResponse()
+            };
+        }
+
+
+        public static TenureViewModel ToResponse(this TenureInformation domain)
+        {
+            return new TenureViewModel
+            {
+                CanRaiseRepair = domain.CanRaiseRepair,
+                TypeCode = domain.TypeCode,
+                TypeDescription = domain.TypeDescription
             };
         }
 

--- a/RepairsApi/V1/Gateways/AlertsGateway.cs
+++ b/RepairsApi/V1/Gateways/AlertsGateway.cs
@@ -20,7 +20,7 @@ namespace RepairsApi.V1.Gateways
             _apiGateway = apiGateway;
         }
 
-        public async Task<PropertyAlertList> GetAlertsAsync(string propertyReference)
+        public async Task<PropertyAlertList> GetLocationAlertsAsync(string propertyReference)
         {
             Uri url = new Uri(_options.AlertsApi + $"cautionary-alerts/properties/{propertyReference}");
 
@@ -38,7 +38,7 @@ namespace RepairsApi.V1.Gateways
         {
             return new PropertyAlertList
             {
-                Alerts = new List<PropertyAlert>(),
+                Alerts = new List<Alert>(),
                 PropertyReference = propertyReference
             };
         }

--- a/RepairsApi/V1/Gateways/AlertsGateway.cs
+++ b/RepairsApi/V1/Gateways/AlertsGateway.cs
@@ -24,17 +24,39 @@ namespace RepairsApi.V1.Gateways
         {
             Uri url = new Uri(_options.AlertsApi + $"cautionary-alerts/properties/{propertyReference}");
 
-            var response = await _apiGateway.ExecuteRequest<AlertsApiResponse>(url);
+            var response = await _apiGateway.ExecuteRequest<PropertyAlertsApiResponse>(url);
 
             if (response.Status == HttpStatusCode.NotFound)
             {
-                return EmptyAlertList(propertyReference);
+                return EmptyPropertyAlertList(propertyReference);
             }
 
             return response.Content.ToDomain();
         }
 
-        private static PropertyAlertList EmptyAlertList(string propertyReference)
+        public async Task<PersonAlertList> GetPersonAlertsAsync(string tenancyReference)
+        {
+            if (tenancyReference == null)
+            {
+                return EmptyPersonAlertList();
+            }
+
+            Uri url = new Uri(_options.AlertsApi + $"cautionary-alerts/people?tag_ref={tenancyReference}");
+
+            var response = await _apiGateway.ExecuteRequest<ListPersonAlertsApiResponse>(url);
+
+            return response.Content.ToDomain();
+        }
+
+        private static PersonAlertList EmptyPersonAlertList()
+        {
+            return new PersonAlertList
+            {
+                Alerts = new List<Alert>()
+            };
+        }
+
+        private static PropertyAlertList EmptyPropertyAlertList(string propertyReference)
         {
             return new PropertyAlertList
             {

--- a/RepairsApi/V1/Gateways/ApiGateway.cs
+++ b/RepairsApi/V1/Gateways/ApiGateway.cs
@@ -19,7 +19,6 @@ namespace RepairsApi.V1.Gateways
         public async Task<ApiResponse<TResponse>> ExecuteRequest<TResponse>(Uri url)
             where TResponse : class
         {
-            var result = await _httpClient.GetAsync(url);
             var client = _clientFactory.CreateClient();
             TResponse response = default;
             var result = await client.GetAsync(url);

--- a/RepairsApi/V1/Gateways/ApiGateway.cs
+++ b/RepairsApi/V1/Gateways/ApiGateway.cs
@@ -1,5 +1,6 @@
 using Newtonsoft.Json;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -7,25 +8,27 @@ namespace RepairsApi.V1.Gateways
 {
     public class ApiGateway : IApiGateway
     {
-        private readonly HttpClient _httpClient;
+        private readonly IHttpClientFactory _clientFactory;
 
-        public ApiGateway(HttpClient httpClient)
+        public ApiGateway(IHttpClientFactory clientFactory)
         {
-            _httpClient = httpClient;
+            _clientFactory = clientFactory;
         }
 
+        [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposal of httpclient from the factory is handled by the factory")]
         public async Task<ApiResponse<TResponse>> ExecuteRequest<TResponse>(Uri url)
             where TResponse : class
         {
             var result = await _httpClient.GetAsync(url);
+            var client = _clientFactory.CreateClient();
             TResponse response = default;
+            var result = await client.GetAsync(url);
 
             if (result.IsSuccessStatusCode)
             {
                 var stringResult = await result.Content.ReadAsStringAsync();
                 response = JsonConvert.DeserializeObject<TResponse>(stringResult);
             }
-
             return new ApiResponse<TResponse>(result.IsSuccessStatusCode, result.StatusCode, response);
         }
     }

--- a/RepairsApi/V1/Gateways/GatewayOptions.cs
+++ b/RepairsApi/V1/Gateways/GatewayOptions.cs
@@ -6,5 +6,6 @@ namespace RepairsApi.V1.Gateways
     {
         public Uri PropertiesAPI { get; set; }
         public Uri AlertsApi { get; set; }
+        public Uri TenancyApi { get; set; }
     }
 }

--- a/RepairsApi/V1/Gateways/IAlertsGateway.cs
+++ b/RepairsApi/V1/Gateways/IAlertsGateway.cs
@@ -5,6 +5,6 @@ namespace RepairsApi.V1.Gateways
 {
     public interface IAlertsGateway
     {
-        Task<PropertyAlertList> GetAlertsAsync(string propertyReference);
+        Task<PropertyAlertList> GetLocationAlertsAsync(string propertyReference);
     }
 }

--- a/RepairsApi/V1/Gateways/IAlertsGateway.cs
+++ b/RepairsApi/V1/Gateways/IAlertsGateway.cs
@@ -6,5 +6,6 @@ namespace RepairsApi.V1.Gateways
     public interface IAlertsGateway
     {
         Task<PropertyAlertList> GetLocationAlertsAsync(string propertyReference);
+        Task<PersonAlertList> GetPersonAlertsAsync(string tenancyReference);
     }
 }

--- a/RepairsApi/V1/Gateways/ITenancyGateway.cs
+++ b/RepairsApi/V1/Gateways/ITenancyGateway.cs
@@ -5,6 +5,6 @@ namespace RepairsApi.V1.Gateways
 {
     public interface ITenancyGateway
     {
-        Task<TenureInformation> GetTenureInformationAsync(string propertyReference);
+        Task<TenureInformation> GetTenancyInformationAsync(string propertyReference);
     }
 }

--- a/RepairsApi/V1/Gateways/ITenancyGateway.cs
+++ b/RepairsApi/V1/Gateways/ITenancyGateway.cs
@@ -1,0 +1,10 @@
+using RepairsApi.V1.Domain;
+using System.Threading.Tasks;
+
+namespace RepairsApi.V1.Gateways
+{
+    public interface ITenancyGateway
+    {
+        Task<TenureInformation> GetTenureInformationAsync(string propertyReference);
+    }
+}

--- a/RepairsApi/V1/Gateways/Models/AlertApiAlertViewModel.cs
+++ b/RepairsApi/V1/Gateways/Models/AlertApiAlertViewModel.cs
@@ -1,13 +1,5 @@
-using System.Collections.Generic;
-
-namespace RepairsApi.V1.Gateways.Models
+﻿namespace RepairsApi.V1.Gateways.Models
 {
-    public class AlertsApiResponse
-    {
-        public string PropertyReference { get; set; }
-        public List<AlertApiAlertViewModel> Alerts { get; set; }
-    }
-
     public class AlertApiAlertViewModel
     {
         public string StartDate { get; set; }

--- a/RepairsApi/V1/Gateways/Models/AlertApiAlertViewModel.cs
+++ b/RepairsApi/V1/Gateways/Models/AlertApiAlertViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace RepairsApi.V1.Gateways.Models
+namespace RepairsApi.V1.Gateways.Models
 {
     public class AlertApiAlertViewModel
     {

--- a/RepairsApi/V1/Gateways/Models/ListTenanciesApiResponse.cs
+++ b/RepairsApi/V1/Gateways/Models/ListTenanciesApiResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace RepairsApi.V1.Gateways.Models
+{
+    public class ListTenanciesApiResponse
+    {
+        public List<TenancyApiTenancyInformation> Tenancies { get; set; }
+    }
+}

--- a/RepairsApi/V1/Gateways/Models/PersonAlertsApiResponse.cs
+++ b/RepairsApi/V1/Gateways/Models/PersonAlertsApiResponse.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace RepairsApi.V1.Gateways.Models
+{
+    public class PersonAlertsApiResponse
+    {
+        public string TenancyAgreementReference { get; set; }
+        public List<AlertApiAlertViewModel> Alerts { get; set; }
+    }
+
+    public class ListPersonAlertsApiResponse
+    {
+        public List<PersonAlertsApiResponse> Contacts { get; set; }
+    }
+}

--- a/RepairsApi/V1/Gateways/Models/PropertyAlertsApiResponse.cs
+++ b/RepairsApi/V1/Gateways/Models/PropertyAlertsApiResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace RepairsApi.V1.Gateways.Models
+{
+    public class PropertyAlertsApiResponse
+    {
+        public string PropertyReference { get; set; }
+        public List<AlertApiAlertViewModel> Alerts { get; set; }
+    }
+}

--- a/RepairsApi/V1/Gateways/Models/TenancyApiTenancyInformation.cs
+++ b/RepairsApi/V1/Gateways/Models/TenancyApiTenancyInformation.cs
@@ -1,0 +1,11 @@
+namespace RepairsApi.V1.Gateways.Models
+{
+    public class TenancyApiTenancyInformation
+    {
+        public string TenancyAgreementReference { get; set; }
+
+        public string TenureType { get; set; }
+
+        public string PropertyReference { get; set; }
+    }
+}

--- a/RepairsApi/V1/Gateways/TenancyGateway.cs
+++ b/RepairsApi/V1/Gateways/TenancyGateway.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Options;
+using RepairsApi.V1.Domain;
+using RepairsApi.V1.Factories;
+using RepairsApi.V1.Gateways.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace RepairsApi.V1.Gateways
+{
+    public class TenancyGateway : ITenancyGateway
+    {
+        private readonly GatewayOptions _options;
+        private readonly IApiGateway _apiGateway;
+
+        public TenancyGateway(IOptions<GatewayOptions> options, IApiGateway apiGateway)
+        {
+            _options = options.Value;
+            _apiGateway = apiGateway;
+        }
+
+        public async Task<TenureInformation> GetTenancyInformationAsync(string propertyReference)
+        {
+            Uri url = new Uri(_options.TenancyApi + $"tenancies?property_reference={propertyReference}");
+
+            var response = await _apiGateway.ExecuteRequest<ListTenanciesApiResponse>(url);
+
+            return response.Content.ToDomain();
+        }
+    }
+}

--- a/RepairsApi/V1/UseCase/GetPropertyUseCase.cs
+++ b/RepairsApi/V1/UseCase/GetPropertyUseCase.cs
@@ -22,12 +22,14 @@ namespace RepairsApi.V1.UseCase
 
             if (property is null) return null;
 
-            var alertList = await _alertsGateway.GetAlertsAsync(propertyReference);
+            var locationAlertList = await _alertsGateway.GetLocationAlertsAsync(propertyReference);
 
             return new PropertyWithAlerts
             {
                 PropertyModel = property,
-                Alerts = alertList.Alerts
+                LocationAlerts = locationAlertList.Alerts,
+                PersonAlerts = null, // TODO
+                Tenure = null // TODO
             };
         }
     }

--- a/RepairsApi/V1/UseCase/GetPropertyUseCase.cs
+++ b/RepairsApi/V1/UseCase/GetPropertyUseCase.cs
@@ -9,11 +9,13 @@ namespace RepairsApi.V1.UseCase
     {
         private readonly IPropertyGateway _propertyGateway;
         private readonly IAlertsGateway _alertsGateway;
+        private readonly ITenancyGateway _tenancyGateway;
 
-        public GetPropertyUseCase(IPropertyGateway propertyGateway, IAlertsGateway alertsGateway)
+        public GetPropertyUseCase(IPropertyGateway propertyGateway, IAlertsGateway alertsGateway, ITenancyGateway tenancyGateway)
         {
             _propertyGateway = propertyGateway;
             _alertsGateway = alertsGateway;
+            _tenancyGateway = tenancyGateway;
         }
 
         public async Task<PropertyWithAlerts> ExecuteAsync(string propertyReference)
@@ -23,13 +25,15 @@ namespace RepairsApi.V1.UseCase
             if (property is null) return null;
 
             var locationAlertList = await _alertsGateway.GetLocationAlertsAsync(propertyReference);
+            var tenureInformation = await _tenancyGateway.GetTenancyInformationAsync(propertyReference);
+            var personAlertList = await _alertsGateway.GetPersonAlertsAsync(tenureInformation?.TenancyAgreementReference);
 
             return new PropertyWithAlerts
             {
                 PropertyModel = property,
                 LocationAlerts = locationAlertList.Alerts,
-                PersonAlerts = null, // TODO
-                Tenure = null // TODO
+                PersonAlerts = personAlertList.Alerts,
+                Tenure = tenureInformation
             };
         }
     }

--- a/RepairsApi/V1/UseCase/Interfaces/IListAlertsUseCase.cs
+++ b/RepairsApi/V1/UseCase/Interfaces/IListAlertsUseCase.cs
@@ -5,6 +5,6 @@ namespace RepairsApi.V1.UseCase.Interfaces
 {
     public interface IListAlertsUseCase
     {
-        Task<PropertyAlertList> ExecuteAsync(string propertyReference);
+        Task<AlertList> ExecuteAsync(string propertyReference);
     }
 }

--- a/RepairsApi/V1/UseCase/ListAlertsUseCase.cs
+++ b/RepairsApi/V1/UseCase/ListAlertsUseCase.cs
@@ -8,19 +8,23 @@ namespace RepairsApi.V1.UseCase
     public class ListAlertsUseCase : IListAlertsUseCase
     {
         private readonly IAlertsGateway _alertsGateway;
+        private readonly ITenancyGateway _tenancyGateway;
 
-        public ListAlertsUseCase(IAlertsGateway alertsGateway)
+        public ListAlertsUseCase(IAlertsGateway alertsGateway, ITenancyGateway tenancyGateway)
         {
             _alertsGateway = alertsGateway;
+            _tenancyGateway = tenancyGateway;
         }
 
         public async Task<AlertList> ExecuteAsync(string propertyReference)
         {
             PropertyAlertList propertyAlertList = await _alertsGateway.GetLocationAlertsAsync(propertyReference);
+            var tenureInformation = await _tenancyGateway.GetTenancyInformationAsync(propertyReference);
+            var personAlertList = await _alertsGateway.GetPersonAlertsAsync(tenureInformation?.TenancyAgreementReference);
             return new AlertList
             {
                 PropertyAlerts = propertyAlertList,
-                PersonAlerts = null // TODO
+                PersonAlerts = personAlertList
             };
         }
     }

--- a/RepairsApi/V1/UseCase/ListAlertsUseCase.cs
+++ b/RepairsApi/V1/UseCase/ListAlertsUseCase.cs
@@ -14,9 +14,14 @@ namespace RepairsApi.V1.UseCase
             _alertsGateway = alertsGateway;
         }
 
-        public Task<PropertyAlertList> ExecuteAsync(string propertyReference)
+        public async Task<AlertList> ExecuteAsync(string propertyReference)
         {
-            return _alertsGateway.GetAlertsAsync(propertyReference);
+            PropertyAlertList propertyAlertList = await _alertsGateway.GetLocationAlertsAsync(propertyReference);
+            return new AlertList
+            {
+                PropertyAlerts = propertyAlertList,
+                PersonAlerts = null // TODO
+            };
         }
     }
 }

--- a/RepairsApi/appsettings.Development.json
+++ b/RepairsApi/appsettings.Development.json
@@ -5,5 +5,11 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "AllowedHosts": "*",
+  "GatewayOptions": {
+    "PropertiesAPI": "http://testpropertiesapi",
+    "AlertsAPI": "http://testpropertiesapi",
+    "TenancyApi": "http://testtenanciesapi"
   }
 }

--- a/RepairsApi/appsettings.IntegrationTests.json
+++ b/RepairsApi/appsettings.IntegrationTests.json
@@ -9,6 +9,6 @@
   "GatewayOptions": {
     "PropertiesAPI": "http://testpropertiesapi/",
     "AlertsAPI": "http://testalertsapi/",
-    "TenancyApi": "http://testtenanciesapi"
+    "TenancyApi": "http://testtenanciesapi/"
   }
 }

--- a/RepairsApi/appsettings.IntegrationTests.json
+++ b/RepairsApi/appsettings.IntegrationTests.json
@@ -8,6 +8,7 @@
   },
   "GatewayOptions": {
     "PropertiesAPI": "http://testpropertiesapi/",
-    "AlertsAPI": "http://testalertsapi/"
+    "AlertsAPI": "http://testalertsapi/",
+    "TenancyApi": "http://testtenanciesapi"
   }
 }

--- a/RepairsApi/appsettings.json
+++ b/RepairsApi/appsettings.json
@@ -9,6 +9,7 @@
   "AllowedHosts": "*",
   "GatewayOptions": {
     "PropertiesAPI": "http://testpropertiesapi",
-    "AlertsAPI": "http://testpropertiesapi"
+    "AlertsAPI": "http://testpropertiesapi",
+    "TenancyApi": "http://testtenanciesapi"
   }
 }

--- a/RepairsApi/appsettings.json
+++ b/RepairsApi/appsettings.json
@@ -6,10 +6,5 @@
       "Microsoft": "Information"
     }
   },
-  "AllowedHosts": "*",
-  "GatewayOptions": {
-    "PropertiesAPI": "http://testpropertiesapi",
-    "AlertsAPI": "http://testpropertiesapi",
-    "TenancyApi": "http://testtenanciesapi"
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Migration of person alert work and tenant information to the .net core api

### *What is the problem we're trying to solve*

This PR adds work made on the rails api week starting 14/12/2020 into the .net core api this includes 
- the addition of person alerts into the get property and get alerts calls
- the addition of the tenancy informtation including canraiserepair into the get property endpoint

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

Are there any next steps that need to addressed after merging this PR? Add them here.
