### PR TITLE
thrown not found for missing work orders

### DIFF
--- a/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
+++ b/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
@@ -156,7 +156,6 @@ namespace RepairsApi.Tests.V2.Controllers
         public async Task ReturnsOkWhenCanCompleteWorkOrder()
         {
             // arrange
-            UseCaseReturns(true);
             const int expectedWorkOrderId = 4;
             var request = CreateRequest(expectedWorkOrderId);
 
@@ -171,15 +170,15 @@ namespace RepairsApi.Tests.V2.Controllers
         public async Task ReturnsBadRequestWhenCantCompleteWorkOrder()
         {
             // arrange
-            UseCaseReturns(false);
             const int expectedWorkOrderId = 4;
             var request = CreateRequest(expectedWorkOrderId);
+            _completeWorkOrderUseCase.Setup(s => s.Execute(It.IsAny<WorkOrderComplete>())).ThrowsAsync(new NotSupportedException());
 
             // act
             var response = await _classUnderTest.WorkOrderComplete(request);
 
             // assert
-            response.Should().BeOfType<BadRequestResult>();
+            response.Should().BeOfType<BadRequestObjectResult>();
         }
 
         [Test]
@@ -203,8 +202,7 @@ namespace RepairsApi.Tests.V2.Controllers
         public async Task ReturnsOkWhenCanUpdateJobStatus()
         {
             _updateJobStatusUseCase
-                .Setup(uc => uc.Execute(It.IsAny<JobStatusUpdate>()))
-                .ReturnsAsync(true);
+                .Setup(uc => uc.Execute(It.IsAny<JobStatusUpdate>())).Returns(Task.CompletedTask);
 
             var response = await _classUnderTest.JobStatusUpdate(
                 new JobStatusUpdate { RelatedWorkOrderReference = new Reference { ID = "42" } });
@@ -216,8 +214,7 @@ namespace RepairsApi.Tests.V2.Controllers
         public async Task ReturnsBadRequestWhenCannotUpdateJobStatus()
         {
             _updateJobStatusUseCase
-                .Setup(uc => uc.Execute(It.IsAny<JobStatusUpdate>()))
-                .ReturnsAsync(false);
+                .Setup(uc => uc.Execute(It.IsAny<JobStatusUpdate>())).ThrowsAsync(new NotSupportedException());
 
             var response = await _classUnderTest.JobStatusUpdate(
                 new JobStatusUpdate { RelatedWorkOrderReference = new Reference { ID = "41" } });
@@ -325,12 +322,6 @@ namespace RepairsApi.Tests.V2.Controllers
             var result = await _classUnderTest.ListWorkOrderTasks(1);
 
             GetStatusCode(result).Should().Be(400);
-        }
-
-        private void UseCaseReturns(bool result)
-        {
-            _completeWorkOrderUseCase.Setup(uc => uc.Execute(It.IsAny<WorkOrderComplete>()))
-                .ReturnsAsync(result);
         }
 
         private List<WorkOrder> CreateWorkOrders()

--- a/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
+++ b/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
@@ -206,6 +206,16 @@ namespace RepairsApi.Tests.V2.E2ETests
             notes.Should().ContainSingle(n => n.Note == expectedNote);
         }
 
+        [Test]
+        public async Task GetMissingWorkOrder()
+        {
+            var client = CreateClient();
+
+            var response = await client.GetAsync(new Uri($"/api/v2/repairs/1000", UriKind.Relative));
+
+            response.StatusCode.Should().Be(404);
+        }
+
         private async Task<int> ScheduleAndUpdateWorkOrder(string updateComments = "comments")
         {
 

--- a/RepairsApi.Tests/V2/UseCase/CompleteWorkOrderUseCaseTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/CompleteWorkOrderUseCaseTests.cs
@@ -13,6 +13,7 @@ using Generated = RepairsApi.V2.Generated;
 using RepairsApi.V2.UseCase;
 using RepairsApi.Tests.Helpers.StubGeneration;
 using RepairsApi.V2.Generated.CustomTypes;
+using RepairsApi.V2.Exceptions;
 
 namespace RepairsApi.Tests.V2.UseCase
 {
@@ -46,10 +47,7 @@ namespace RepairsApi.Tests.V2.UseCase
             var workOrderCompleteRequest = CreateRequest(expectedWorkOrder.Id);
 
             // act
-            var result = await _classUnderTest.Execute(workOrderCompleteRequest);
-
-            // assert
-            result.Should().BeTrue();
+            await _classUnderTest.Execute(workOrderCompleteRequest);
 
             var lastWorkOrderComplete = _workOrderCompletionGatewayMock.LastWorkOrderComplete;
             lastWorkOrderComplete.Should().NotBeNull();
@@ -71,10 +69,7 @@ namespace RepairsApi.Tests.V2.UseCase
             };
 
             // act
-            var result = await _classUnderTest.Execute(workOrderCompleteRequest);
-
-            // assert
-            result.Should().BeTrue();
+            await _classUnderTest.Execute(workOrderCompleteRequest);
 
             var lastWorkOrderComplete = _workOrderCompletionGatewayMock.LastWorkOrderComplete;
             lastWorkOrderComplete.Should().NotBeNull();
@@ -82,29 +77,16 @@ namespace RepairsApi.Tests.V2.UseCase
         }
 
         [Test]
-        public async Task ReturnFalseWhenWorkOrderDoesntExist()
-        {
-            // arrange
-            var expectedWorkOrderId = 5;
-
-            // act
-            var result = await _classUnderTest.Execute(CreateRequest(expectedWorkOrderId));
-
-            // assert
-            result.Should().BeFalse();
-        }
-
-        [Test]
         public async Task ReturnFalseWhenAlreadyComplete()
         {
             // arrange
-            _workOrderCompletionGatewayMock.Setup(m => m.IsWorkOrderCompleted(It.IsAny<int>())).ReturnsAsync(false);
+            _workOrderCompletionGatewayMock.Setup(m => m.IsWorkOrderCompleted(It.IsAny<int>())).ReturnsAsync(true);
 
             // act
-            var result = await _classUnderTest.Execute(CreateRequest(1));
+            Func<Task> fn = async () => await _classUnderTest.Execute(CreateRequest(1));
 
             // assert
-            result.Should().BeFalse();
+            await fn.Should().ThrowAsync<NotSupportedException>();
         }
 
         [Test]
@@ -203,10 +185,9 @@ namespace RepairsApi.Tests.V2.UseCase
             };
 
             // act
-            var result = await _classUnderTest.Execute(workOrderCompleteRequest);
+            await _classUnderTest.Execute(workOrderCompleteRequest);
 
             // assert
-            result.Should().BeTrue();
             _repairsGatewayMock.Verify(rgm => rgm.UpdateWorkOrderStatus(expectedWorkOrder.Id, expectedNewStatus));
         }
 

--- a/RepairsApi.Tests/V2/UseCase/JobStatusUpdateUseCases/MoreSpecificSorCodeTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/JobStatusUpdateUseCases/MoreSpecificSorCodeTests.cs
@@ -104,7 +104,8 @@ namespace RepairsApi.Tests.V2.UseCase.JobStatusUpdateUseCases
             };
             var request = CreateMoreSpecificSORUpdateRequest(desiredWorkOrderId, workOrder, expectedNewCode);
 
-            Assert.ThrowsAsync<ResourceNotFoundException>(() => _classUnderTest.Execute(request));
+            Func<Task> fn = () => _classUnderTest.Execute(request);
+            fn.Should().ThrowAsync<ResourceNotFoundException>();
         }
 
         private static RateScheduleItem CloneRateScheduleItem(RateScheduleItem toModify)

--- a/RepairsApi.Tests/V2/UseCase/ListWorkOrderNotesUseCaseTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/ListWorkOrderNotesUseCaseTests.cs
@@ -50,16 +50,6 @@ namespace RepairsApi.Tests.V2.UseCase
                 });
         }
 
-        [Test]
-        public async Task ThrowWhenNotFound()
-        {
-            _repairsGatewayMock.Setup(m => m.GetWorkOrder(It.IsAny<int>())).ReturnsAsync((WorkOrder) null);
-
-            Func<Task> sutFunc = async () => await _classUnderTest.Execute(1);
-
-            await sutFunc.Should().ThrowAsync<ResourceNotFoundException>();
-        }
-
         private DateTime RandomDay()
         {
             var start = new DateTime(1995, 1, 1);

--- a/RepairsApi.Tests/V2/UseCase/UpdateJobStatusUseCaseTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/UpdateJobStatusUseCaseTests.cs
@@ -12,6 +12,7 @@ using RepairsApi.V2.Infrastructure;
 using RepairsApi.V2.UseCase;
 using RepairsApi.V2.UseCase.JobStatusUpdatesUseCases;
 using Generated = RepairsApi.V2.Generated;
+using RepairsApi.V2.Exceptions;
 
 namespace RepairsApi.Tests.V2.UseCase
 {
@@ -42,7 +43,7 @@ namespace RepairsApi.Tests.V2.UseCase
         }
 
         [Test]
-        public async Task CanUpdateJobStatus()
+        public void CanUpdateJobStatus()
         {
             const int desiredWorkOrderId = 42;
             _jobStatusUpdateGateway.Setup(gateway => gateway.CreateJobStatusUpdate(It.Is<JobStatusUpdate>(jsu => jsu.RelatedWorkOrder.Id == desiredWorkOrderId)))
@@ -57,7 +58,7 @@ namespace RepairsApi.Tests.V2.UseCase
             _repairsGatewayMock.Setup(gateway => gateway.GetWorkElementsForWorkOrder(It.Is<WorkOrder>(wo => wo.Id == desiredWorkOrderId)))
                 .ReturnsAsync(_fixture.Create<List<WorkElement>>);
 
-            var result = await _classUnderTest.Execute(
+            Assert.DoesNotThrowAsync(async () => await _classUnderTest.Execute(
                 new Generated.JobStatusUpdate
                 {
                     RelatedWorkOrderReference = new Generated.Reference
@@ -65,25 +66,7 @@ namespace RepairsApi.Tests.V2.UseCase
                         ID = "42"
                     },
                     TypeCode = Generated.JobStatusUpdateTypeCode._0
-                });
-
-            result.Should().BeTrue();
-        }
-
-        [Test]
-        public async Task ReturnFalseWhenWorkOrderDoesntExist()
-        {
-            var result = await _classUnderTest.Execute(
-                new Generated.JobStatusUpdate
-                {
-                    RelatedWorkOrderReference = new Generated.Reference
-                    {
-                        ID = "41"
-                    }
-                });
-
-            // assert
-            result.Should().BeFalse();
+                }));
         }
 
         [Test]
@@ -118,9 +101,8 @@ namespace RepairsApi.Tests.V2.UseCase
             _repairsGatewayMock.Setup(gateway => gateway.GetWorkElementsForWorkOrder(It.Is<WorkOrder>(wo => wo.Id == desiredWorkOrderId)))
                 .ReturnsAsync(_fixture.Create<List<WorkElement>>);
 
-            var result = await _classUnderTest.Execute(CreateMoreSpecificSORUpdateRequest(desiredWorkOrderId, workOrder, "code"));
+            await _classUnderTest.Execute(CreateMoreSpecificSORUpdateRequest(desiredWorkOrderId, workOrder, "code"));
 
-            result.Should().BeTrue();
             _strategyFactory.Verify(uc => uc.ProcessActions(It.IsAny<Generated.JobStatusUpdate>()));
         }
 

--- a/RepairsApi/V2/Controllers/RepairsController.cs
+++ b/RepairsApi/V2/Controllers/RepairsController.cs
@@ -130,12 +130,16 @@ namespace RepairsApi.V2.Controllers
         {
             try
             {
-                var result = await _completeWorkOrderUseCase.Execute(request);
-                return result ? (IActionResult) Ok() : BadRequest();
+                await _completeWorkOrderUseCase.Execute(request);
+                return Ok();
             }
             catch (NotSupportedException e)
             {
                 return BadRequest(e.Message);
+            }
+            catch (ResourceNotFoundException e)
+            {
+                return NotFound(e.Message);
             }
         }
 
@@ -150,8 +154,8 @@ namespace RepairsApi.V2.Controllers
         {
             try
             {
-                var result = await _updateJobStatusUseCase.Execute(request);
-                return result ? (IActionResult) Ok() : BadRequest("No WorkOrder was found with the provided ID.");
+                await _updateJobStatusUseCase.Execute(request);
+                return Ok();
             }
             catch (NotSupportedException e)
             {

--- a/RepairsApi/V2/Factories/ResponseFactory.cs
+++ b/RepairsApi/V2/Factories/ResponseFactory.cs
@@ -110,18 +110,18 @@ namespace RepairsApi.V2.Factories
 
         public static WorkOrderResponse ToResponse(this Infrastructure.WorkOrder workOrder)
         {
-            Infrastructure.PropertyClass propertyClass = workOrder.Site?.PropertyClass.FirstOrDefault();
+            Infrastructure.PropertyClass propertyClass = workOrder.Site?.PropertyClass?.FirstOrDefault();
             string addressLine = propertyClass?.Address?.AddressLine;
             return new WorkOrderResponse
             {
                 Reference = workOrder.Id,
                 Description = workOrder.DescriptionOfWork,
-                Priority = workOrder.WorkPriority.PriorityDescription,
+                Priority = workOrder.WorkPriority?.PriorityDescription,
                 Property = addressLine,
                 DateRaised = workOrder.DateRaised,
-                PropertyReference = workOrder.Site?.PropertyClass.FirstOrDefault()?.PropertyReference,
-                Target = workOrder.WorkPriority.RequiredCompletionDateTime,
-                PriorityCode = workOrder.WorkPriority.PriorityCode,
+                PropertyReference = workOrder.Site?.PropertyClass?.FirstOrDefault()?.PropertyReference,
+                Target = workOrder.WorkPriority?.RequiredCompletionDateTime,
+                PriorityCode = workOrder.WorkPriority?.PriorityCode,
                 LastUpdated = null,
                 Owner = workOrder.AssignedToPrimary?.Name,
                 RaisedBy = workOrder.AgentName,
@@ -134,18 +134,18 @@ namespace RepairsApi.V2.Factories
 
         public static WorkOrderListItem ToListItem(this Infrastructure.WorkOrder workOrder)
         {
-            Infrastructure.PropertyClass propertyClass = workOrder.Site?.PropertyClass.FirstOrDefault();
+            Infrastructure.PropertyClass propertyClass = workOrder.Site?.PropertyClass?.FirstOrDefault();
             string addressLine = propertyClass?.Address?.AddressLine;
             return new WorkOrderListItem
             {
                 Reference = workOrder.Id,
                 Description = workOrder.DescriptionOfWork,
                 Owner = workOrder.AssignedToPrimary?.Name,
-                Priority = workOrder.WorkPriority.PriorityDescription,
+                Priority = workOrder.WorkPriority?.PriorityDescription,
                 Property = addressLine,
                 DateRaised = workOrder.DateRaised,
                 LastUpdated = null,
-                PropertyReference = workOrder.Site?.PropertyClass.FirstOrDefault()?.PropertyReference,
+                PropertyReference = workOrder.Site?.PropertyClass?.FirstOrDefault()?.PropertyReference,
                 TradeCode = workOrder.WorkElements.FirstOrDefault()?.Trade.FirstOrDefault()?.CustomCode,
                 Status = workOrder.GetStatus()
             };

--- a/RepairsApi/V2/Gateways/IRepairsGateway.cs
+++ b/RepairsApi/V2/Gateways/IRepairsGateway.cs
@@ -11,7 +11,7 @@ namespace RepairsApi.V2.Gateways
     {
         Task<int> CreateWorkOrder(WorkOrder raiseRepair);
         Task<IEnumerable<WorkOrder>> GetWorkOrders(params Expression<Func<WorkOrder, bool>>[] whereExpressions);
-        Task<WorkOrder?> GetWorkOrder(int id);
+        Task<WorkOrder> GetWorkOrder(int id);
         Task<IEnumerable<WorkElement>> GetWorkElementsForWorkOrder(WorkOrder workOrder);
         Task<IEnumerable<WorkElement>> GetWorkElementsForWorkOrder(int id);
         Task UpdateWorkOrderStatus(int workOrderId, WorkStatusCode canceled);

--- a/RepairsApi/V2/Gateways/RepairsGateway.cs
+++ b/RepairsApi/V2/Gateways/RepairsGateway.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Linq.Expressions;
+using RepairsApi.V2.Exceptions;
 
 namespace RepairsApi.V2.Gateways
 {
@@ -39,7 +40,14 @@ namespace RepairsApi.V2.Gateways
 
         public async Task<WorkOrder> GetWorkOrder(int id)
         {
-            return await _repairsContext.WorkOrders.FindAsync(id);
+            WorkOrder workOrder = await _repairsContext.WorkOrders.FindAsync(id);
+
+            if (workOrder is null)
+            {
+                throw new ResourceNotFoundException($"Unable to locate work order {id}");
+            }
+
+            return workOrder;
         }
 
         public async Task<IEnumerable<WorkElement>> GetWorkElementsForWorkOrder(WorkOrder workOrder)

--- a/RepairsApi/V2/UseCase/Interfaces/ICompleteWorkOrderUseCase.cs
+++ b/RepairsApi/V2/UseCase/Interfaces/ICompleteWorkOrderUseCase.cs
@@ -5,7 +5,7 @@ namespace RepairsApi.V2.UseCase.Interfaces
 {
     public interface ICompleteWorkOrderUseCase
     {
-        Task<bool> Execute(WorkOrderComplete request);
+        Task Execute(WorkOrderComplete request);
     }
 
 }

--- a/RepairsApi/V2/UseCase/Interfaces/IUpdateJobStatusUseCase.cs
+++ b/RepairsApi/V2/UseCase/Interfaces/IUpdateJobStatusUseCase.cs
@@ -5,6 +5,6 @@ namespace RepairsApi.V2.UseCase.Interfaces
 {
     public interface IUpdateJobStatusUseCase
     {
-        Task<bool> Execute(JobStatusUpdate jobStatusUpdate);
+        Task Execute(JobStatusUpdate jobStatusUpdate);
     }
 }

--- a/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/MoreSpecificSorUseCase.cs
+++ b/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/MoreSpecificSorUseCase.cs
@@ -28,11 +28,6 @@ namespace RepairsApi.V2.UseCase.JobStatusUpdatesUseCases
 
             var workOrder = await _repairsGateway.GetWorkOrder(workOrderId);
 
-            if (workOrder == null)
-            {
-                throw new ResourceNotFoundException($"Unable to locate work order {workOrderId}");
-            }
-
             var existingCodes = workOrder.WorkElements.SelectMany(we => we.RateScheduleItem);
             var newCodes = workElement.RateScheduleItem.Where(rsi => !existingCodes.Any(ec => ec.CustomCode == rsi.CustomCode));
 

--- a/RepairsApi/V2/UseCase/ListWorkOrderNotesUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrderNotesUseCase.cs
@@ -23,11 +23,6 @@ namespace RepairsApi.V2.UseCase
         {
             var workOrder = await _repairsGatway.GetWorkOrder(id);
 
-            if (workOrder == null)
-            {
-                throw new ResourceNotFoundException($"Unable to find work order: {id}");
-            }
-
             return workOrder.JobStatusUpdates?
                 .Where(jsu => !jsu.Comments.IsNullOrEmpty())
                 .Where(jsu => jsu.EventTime.HasValue)

--- a/RepairsApi/V2/UseCase/UpdateJobStatusUseCase.cs
+++ b/RepairsApi/V2/UseCase/UpdateJobStatusUseCase.cs
@@ -29,20 +29,17 @@ namespace RepairsApi.V2.UseCase
             _strategyFactory = strategyFactory;
         }
 
-        public async Task<bool> Execute(JobStatusUpdate jobStatusUpdate)
+        public async Task Execute(JobStatusUpdate jobStatusUpdate)
         {
             var workOrderId = int.Parse(jobStatusUpdate.RelatedWorkOrderReference.ID);
 
             var workOrder = await _repairsGateway.GetWorkOrder(workOrderId);
-            if (workOrder is null) return false;
 
             var workElements = await _repairsGateway.GetWorkElementsForWorkOrder(workOrder);
 
             await _strategyFactory.ProcessActions(jobStatusUpdate);
 
             await _jobStatusUpdateGateway.CreateJobStatusUpdate(jobStatusUpdate.ToDb(workElements, workOrder));
-
-            return true;
         }
 
     }


### PR DESCRIPTION
Throwing a not found when asking for a work order that doesnt existing rather than sending round magic booleans.

Mergin into master as a hotfix that can be merged up into develop so that the appointment and sor by trade work doesnt have to go into staging