### PR TITLE
Trades by prop ref

### DIFF
--- a/RepairsApi.Tests/V2/E2ETests/ScheduleOfRateCodesTests.cs
+++ b/RepairsApi.Tests/V2/E2ETests/ScheduleOfRateCodesTests.cs
@@ -28,7 +28,7 @@ namespace RepairsApi.Tests.V2.E2ETests
 
         private static async Task<IEnumerable<SorTradeResponse>> GetTrades(HttpClient client)
         {
-            var response = await client.GetAsync(new Uri("/api/v2/schedule-of-rates/trades", UriKind.Relative));
+            var response = await client.GetAsync(new Uri($"/api/v2/schedule-of-rates/trades?propref={TestDataSeeder.PropRef}", UriKind.Relative));
 
             response.StatusCode.Should().Be(200);
 

--- a/RepairsApi.Tests/V2/Gateways/ScheduleOfRatesGatewayTests.cs
+++ b/RepairsApi.Tests/V2/Gateways/ScheduleOfRatesGatewayTests.cs
@@ -41,7 +41,7 @@ namespace RepairsApi.Tests.V2.Gateways
             var validContracts = await SeedContracts(expectedProperty, DateTime.UtcNow.AddDays(-7), DateTime.UtcNow.AddDays(7), contractorReference);
             await SeedSorCodes(expectedPriority, expectedProperty, expectedTrade, validContracts.First());
             await InMemoryDb.Instance.SaveChangesAsync();
-            
+
             // act
             var result = await _classUnderTest.GetTrades(expectedProperty);
 

--- a/RepairsApi.Tests/V2/Gateways/ScheduleOfRatesGatewayTests.cs
+++ b/RepairsApi.Tests/V2/Gateways/ScheduleOfRatesGatewayTests.cs
@@ -33,17 +33,20 @@ namespace RepairsApi.Tests.V2.Gateways
         public async Task CanGetTrades()
         {
             // arrange
-            var generator = new Generator<SorCodeTrade>();
-            generator.AddDefaultGenerators();
-            var expectedTrades = generator.GenerateList(10);
-            await InMemoryDb.Instance.Trades.AddRangeAsync(expectedTrades);
+            const string expectedProperty = "property";
+            var expectedPriority = await SeedPriority();
+            string contractorReference = "contractor";
+            await SeedContractor(contractorReference);
+            var expectedTrade = await SeedTrade(Guid.NewGuid().ToString());
+            var validContracts = await SeedContracts(expectedProperty, DateTime.UtcNow.AddDays(-7), DateTime.UtcNow.AddDays(7), contractorReference);
+            await SeedSorCodes(expectedPriority, expectedProperty, expectedTrade, validContracts.First());
             await InMemoryDb.Instance.SaveChangesAsync();
-
+            
             // act
-            var result = await _classUnderTest.GetTrades();
+            var result = await _classUnderTest.GetTrades(expectedProperty);
 
             // assert
-            result.Should().BeEquivalentTo(expectedTrades);
+            result.Single().Should().BeEquivalentTo(expectedTrade);
         }
 
         [Test]

--- a/RepairsApi/V2/Controllers/ScheduleOfRatesController.cs
+++ b/RepairsApi/V2/Controllers/ScheduleOfRatesController.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using RepairsApi.V2.Gateways;
 using RepairsApi.V2.Infrastructure.Hackney;
+using System.ComponentModel.DataAnnotations;
 
 namespace RepairsApi.V2.Controllers
 {
@@ -56,9 +57,9 @@ namespace RepairsApi.V2.Controllers
         [ProducesResponseType(typeof(IEnumerable<SorTradeResponse>), StatusCodes.Status200OK)]
         [Route("trades")]
         [HttpGet]
-        public async Task<IActionResult> ListTrades()
+        public async Task<IActionResult> ListTrades([FromQuery][Required]string propRef)
         {
-            return Ok(await _listSorTrades.Execute());
+            return Ok(await _listSorTrades.Execute(propRef));
         }
 
 

--- a/RepairsApi/V2/Controllers/ScheduleOfRatesController.cs
+++ b/RepairsApi/V2/Controllers/ScheduleOfRatesController.cs
@@ -57,7 +57,7 @@ namespace RepairsApi.V2.Controllers
         [ProducesResponseType(typeof(IEnumerable<SorTradeResponse>), StatusCodes.Status200OK)]
         [Route("trades")]
         [HttpGet]
-        public async Task<IActionResult> ListTrades([FromQuery][Required]string propRef)
+        public async Task<IActionResult> ListTrades([FromQuery][Required] string propRef)
         {
             return Ok(await _listSorTrades.Execute(propRef));
         }

--- a/RepairsApi/V2/Gateways/IScheduleOfRatesGateway.cs
+++ b/RepairsApi/V2/Gateways/IScheduleOfRatesGateway.cs
@@ -11,7 +11,7 @@ namespace RepairsApi.V2.Gateways
 {
     public interface IScheduleOfRatesGateway
     {
-        Task<IEnumerable<SorCodeTrade>> GetTrades();
+        Task<IEnumerable<SorCodeTrade>> GetTrades(string propRef);
         Task<IEnumerable<ScheduleOfRatesModel>> GetSorCodes(string propertyReference, string tradeCode, string contractorReference);
         Task<double?> GetCost(string contractReference, string sorCode);
         Task<IEnumerable<string>> GetContracts(string contractorReference);

--- a/RepairsApi/V2/UseCase/Interfaces/IListSorTradesUseCase.cs
+++ b/RepairsApi/V2/UseCase/Interfaces/IListSorTradesUseCase.cs
@@ -6,6 +6,6 @@ namespace RepairsApi.V2.UseCase.Interfaces
 {
     public interface IListSorTradesUseCase
     {
-        Task<IEnumerable<SorTradeResponse>> Execute();
+        Task<IEnumerable<SorTradeResponse>> Execute(string propRef);
     }
 }

--- a/RepairsApi/V2/UseCase/ListSorTradesUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListSorTradesUseCase.cs
@@ -18,9 +18,9 @@ namespace RepairsApi.V2.UseCase
             _scheduleOfRatesGateway = scheduleOfRatesGateway;
         }
 
-        public async Task<IEnumerable<SorTradeResponse>> Execute()
+        public async Task<IEnumerable<SorTradeResponse>> Execute(string propRef)
         {
-            var sorCodes = await _scheduleOfRatesGateway.GetTrades();
+            var sorCodes = await _scheduleOfRatesGateway.GetTrades(propRef);
             return sorCodes.Select(c => c.ToResponse());
         }
     }


### PR DESCRIPTION
Applying this patch will change the GET trades endpoint 
- It will require a property reference to function
- It will now only returns trades with valid contractors and sor codes 