### PR TITLE
Spend limits

### DIFF
--- a/RepairsApi.Tests/Helpers/StubGeneration/ObjectFaker.cs
+++ b/RepairsApi.Tests/Helpers/StubGeneration/ObjectFaker.cs
@@ -47,6 +47,7 @@ namespace RepairsApi.Tests.Helpers.StubGeneration
                 if (accessor.Body.NodeType != ExpressionType.MemberAccess) throw new Exception("accessor must be simple property accessor eg obj.prop");
                 MemberExpression casted = accessor.Body as MemberExpression;
 
+                if (_propertyGenerators.ContainsKey(casted.Member)) _propertyGenerators.Remove(casted.Member);
                 _propertyGenerators.TryAdd(casted.Member, generator);
             }
 

--- a/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
+++ b/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
@@ -108,7 +108,9 @@ namespace RepairsApi.Tests.Helpers.StubGeneration
             return generator
                 .AddDefaultGenerators()
                 .AddWorkOrderGenerators()
-                .AddValue(null, (RepairsApi.V2.Generated.JobStatusUpdate jsu) => jsu.AdditionalWork);
+                .AddValue(null, (RepairsApi.V2.Generated.JobStatusUpdate jsu) => jsu.AdditionalWork)
+                .SetListLength<WorkElement>(1)
+                .SetListLength<RateScheduleItem>(1);
         }
     }
 }

--- a/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
+++ b/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
@@ -65,11 +65,14 @@ namespace RepairsApi.Tests.Helpers.StubGeneration
                 .SetListLength<RateScheduleItem>(1);
         }
 
-        public static Generator<T> WithSorCodes<T>(this Generator<T> generator, params string[] sorCodes)
+        public static Generator<T> WithSorCodes<T>(this Generator<T> generator, params (string sorCode,string contractorRef)[] sorCodes)
         {
             Random rand = new Random();
+            var sorCode = sorCodes[rand.Next(sorCodes.Length)];
 
-            return generator.AddGenerator(() => sorCodes[rand.Next(sorCodes.Length)], (RateScheduleItem rsi) => rsi.CustomCode);
+            return generator
+                .AddGenerator(() => sorCode.sorCode, (RateScheduleItem rsi) => rsi.CustomCode)
+                .AddGenerator(() => sorCode.contractorRef, (Reference r) => r.ID);
         }
 
         public static Generator<T> AddInfrastructureWorkOrderGenerators<T>(this Generator<T> generator)

--- a/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
+++ b/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
@@ -2,6 +2,7 @@ using Bogus;
 using RepairsApi.V2.Generated;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using JobStatusUpdate = RepairsApi.V2.Infrastructure.JobStatusUpdate;
 
@@ -82,6 +83,21 @@ namespace RepairsApi.Tests.Helpers.StubGeneration
             return generator
                 .AddGenerator(() => sorCode.sorCode, (RateScheduleItem rsi) => rsi.CustomCode)
                 .AddGenerator(() => sorCode.contractorRef, (Reference r) => r.ID);
+        }
+
+        public static Generator<T> WithValidCodes<T>(this Generator<T> generator, RepairsApi.V2.Infrastructure.RepairsContext ctx)
+        {
+            var sorCodes = ctx.SORCodes
+                .Select(sor => new { sor.Code, sor.SorCodeMap.FirstOrDefault().Contract.ContractorReference })
+                .Where(c => !string.IsNullOrEmpty(c.ContractorReference))
+                .ToArray();
+
+            Random rand = new Random();
+            var sorCode = sorCodes[rand.Next(sorCodes.Length)];
+
+            return generator
+                .AddGenerator(() => sorCode.Code, (RateScheduleItem rsi) => rsi.CustomCode)
+                .AddGenerator(() => sorCode.ContractorReference, (Reference r) => r.ID);
         }
 
         public static Generator<T> AddInfrastructureWorkOrderGenerators<T>(this Generator<T> generator)

--- a/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
+++ b/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
@@ -75,29 +75,13 @@ namespace RepairsApi.Tests.Helpers.StubGeneration
                 .SetListLength<RateScheduleItem>(1);
         }
 
-        public static Generator<T> WithSorCodes<T>(this Generator<T> generator, params (string sorCode,string contractorRef)[] sorCodes)
+        public static Generator<T> WithSorCodes<T>(this Generator<T> generator, params string[] sorCodes)
         {
             Random rand = new Random();
             var sorCode = sorCodes[rand.Next(sorCodes.Length)];
 
             return generator
-                .AddGenerator(() => sorCode.sorCode, (RateScheduleItem rsi) => rsi.CustomCode)
-                .AddGenerator(() => sorCode.contractorRef, (Reference r) => r.ID);
-        }
-
-        public static Generator<T> WithValidCodes<T>(this Generator<T> generator, RepairsApi.V2.Infrastructure.RepairsContext ctx)
-        {
-            var sorCodes = ctx.SORCodes
-                .Select(sor => new { sor.Code, sor.SorCodeMap.FirstOrDefault().Contract.ContractorReference })
-                .Where(c => !string.IsNullOrEmpty(c.ContractorReference))
-                .ToArray();
-
-            Random rand = new Random();
-            var sorCode = sorCodes[rand.Next(sorCodes.Length)];
-
-            return generator
-                .AddGenerator(() => sorCode.Code, (RateScheduleItem rsi) => rsi.CustomCode)
-                .AddGenerator(() => sorCode.ContractorReference, (Reference r) => r.ID);
+                .AddGenerator(() => sorCode, (RateScheduleItem rsi) => rsi.CustomCode);
         }
 
         public static Generator<T> AddInfrastructureWorkOrderGenerators<T>(this Generator<T> generator)

--- a/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
+++ b/RepairsApi.Tests/Helpers/StubGeneration/ObjectGenerationExtensions.cs
@@ -65,6 +65,7 @@ namespace RepairsApi.Tests.Helpers.StubGeneration
                 .AddValue(GetSitePropertyUnitGenerator(), (RaiseRepair rr) => rr.SitePropertyUnit)
                 .AddValue(new List<double> { 2.0 }, (Quantity q) => q.Amount)
                 .AddValue(contractorReference, (Party p) => p.Reference)
+                .AddValue(TestDataSeeder.SorCode, (RateScheduleItem rsi) => rsi.CustomCode)
                 .AddValue(new string[] { "2.0" },
                     (GeographicalLocation q) => q.Latitude,
                     (GeographicalLocation q) => q.Longitude,

--- a/RepairsApi.Tests/HttpClientExtensions.cs
+++ b/RepairsApi.Tests/HttpClientExtensions.cs
@@ -32,7 +32,8 @@ namespace RepairsApi.Tests
                 Email = TestUserInformation.EMAIL,
                 Groups = new List<string>()
                 {
-                    "agent"
+                    "agent",
+                    "raise50"
                 }
             });
         }

--- a/RepairsApi.Tests/HttpClientExtensions.cs
+++ b/RepairsApi.Tests/HttpClientExtensions.cs
@@ -31,7 +31,8 @@ namespace RepairsApi.Tests
                 Groups = new List<string>()
                 {
                     "repairs-hub-frontend-staging",
-                    "repairs-hub-frontend-staging-limit50"
+                    "repairs-hub-frontend-staging-raiselimit50",
+                    "repairs-hub-frontend-staging-varylimit50"
                 }
             });
         }

--- a/RepairsApi.Tests/HttpClientExtensions.cs
+++ b/RepairsApi.Tests/HttpClientExtensions.cs
@@ -33,7 +33,8 @@ namespace RepairsApi.Tests
                 Groups = new List<string>()
                 {
                     "agent",
-                    "raise50"
+                    "raise50",
+                    "vary50"
                 }
             });
         }
@@ -46,7 +47,9 @@ namespace RepairsApi.Tests
                 Email = TestUserInformation.EMAIL,
                 Groups = new List<string>()
                 {
-                    group
+                    group,
+                    "raise50",
+                    "vary50"
                 }
             });
         }

--- a/RepairsApi.Tests/HttpClientExtensions.cs
+++ b/RepairsApi.Tests/HttpClientExtensions.cs
@@ -30,7 +30,8 @@ namespace RepairsApi.Tests
                 Email = TestUserInformation.EMAIL,
                 Groups = new List<string>()
                 {
-                    "repairs-hub-frontend-staging"
+                    "repairs-hub-frontend-staging",
+                    "repairs-hub-frontend-staging-limit50"
                 }
             });
         }

--- a/RepairsApi.Tests/MockWebApplicationFactory.cs
+++ b/RepairsApi.Tests/MockWebApplicationFactory.cs
@@ -85,12 +85,9 @@ namespace RepairsApi.Tests
             dbContext.SaveChanges();
         }
 
-        protected void WithContext(Action<RepairsContext> action)
+        protected ScopedContext GetContext()
         {
-            using var scope = Services.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<RepairsContext>();
-
-            action(dbContext);
+            return new ScopedContext(Services);
         }
 
         protected string GetGroup(string contractor)
@@ -98,6 +95,24 @@ namespace RepairsApi.Tests
             var groups = Server.Services.GetService<IOptions<GroupOptions>>().Value;
 
             return groups.SecurityGroups.Where(kv => kv.Value.ContractorReference == contractor).Select(kv => kv.Key).Single();
+        }
+    }
+
+    public sealed class ScopedContext : IDisposable
+    {
+        private readonly IServiceScope _scope;
+
+        public RepairsContext DB { get; private set; }
+
+        public ScopedContext(IServiceProvider services)
+        {
+            _scope = services.CreateScope();
+            DB = _scope.ServiceProvider.GetRequiredService<RepairsContext>();
+        }
+
+        public void Dispose()
+        {
+            _scope.Dispose();
         }
     }
 }

--- a/RepairsApi.Tests/TestDataSeeder.cs
+++ b/RepairsApi.Tests/TestDataSeeder.cs
@@ -65,14 +65,20 @@ namespace RepairsApi.Tests
 
         private static void SeedSorMap(RepairsContext ctx)
         {
-            var generator = new Generator<SORContract>()
-                .AddDefaultGenerators()
-                .AddGenerator(() => PickCode(ContractReferences), (SORContract c) => c.ContractReference)
-                .AddGenerator(() => PickCode(SorCodes), (SORContract c) => c.SorCodeCode)
-                .Ignore((SORContract c) => c.Contract)
-                .Ignore((SORContract c) => c.SorCode);
+            List<SORContract> entities = new List<SORContract>();
 
-            IEnumerable<SORContract> entities = generator.GenerateList(100).Distinct();
+            foreach (var code in SorCodes)
+            {
+                foreach (var contract in ContractReferences)
+                {
+                    entities.Add(new SORContract
+                    {
+                        ContractReference = contract,
+                        Cost = 5,
+                        SorCodeCode = code
+                    });
+                }
+            }
 
             ctx.Set<SORContract>().AddRange(entities);
             ctx.Set<SORContract>().Add(new SORContract
@@ -91,7 +97,7 @@ namespace RepairsApi.Tests
                 .AddGenerator(() => PickCode(PropertyReferences), (PropertyContract c) => c.PropRef)
                 .Ignore((PropertyContract c) => c.Contract);
 
-            IEnumerable<PropertyContract> entities = generator.GenerateList(100).Distinct();
+            IEnumerable<PropertyContract> entities = generator.GenerateList(40).Distinct();
 
             ctx.Set<PropertyContract>().AddRange(entities);
             ctx.Set<PropertyContract>().Add(new PropertyContract
@@ -113,7 +119,7 @@ namespace RepairsApi.Tests
                 .Ignore((Contract c) => c.SorCodeMap)
                 .Ignore((Contract c) => c.Contractor);
 
-            ctx.Set<Contract>().AddRange(generator.GenerateList(100));
+            ctx.Set<Contract>().AddRange(generator.GenerateList(10));
             ctx.Set<Contract>().Add(new Contract
             {
                 ContractorReference = Contractor,
@@ -130,7 +136,7 @@ namespace RepairsApi.Tests
                 .AddGenerator(() => SeedCode(ContractorReferences), (Contractor c) => c.Reference)
                 .AddValue(null, (Contractor c) => c.Contracts);
 
-            ctx.Set<Contractor>().AddRange(generator.GenerateList(100));
+            ctx.Set<Contractor>().AddRange(generator.GenerateList(5));
             ctx.Set<Contractor>().Add(new Contractor
             {
                 Name = Contractor,
@@ -140,7 +146,7 @@ namespace RepairsApi.Tests
 
         private static void SeedPropref()
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 5; i++)
             {
                 SeedCode(PropertyReferences);
             }
@@ -158,7 +164,7 @@ namespace RepairsApi.Tests
                 .Ignore((ScheduleOfRates sor) => sor.Trade)
                 .Ignore((ScheduleOfRates sor) => sor.SorCodeMap);
 
-            ctx.Set<ScheduleOfRates>().AddRange(generator.GenerateList(100));
+            ctx.Set<ScheduleOfRates>().AddRange(generator.GenerateList(10));
             ctx.Set<ScheduleOfRates>().Add(new ScheduleOfRates
             {
                 Enabled = true,
@@ -177,7 +183,7 @@ namespace RepairsApi.Tests
                 .AddDefaultGenerators()
                 .AddGenerator(() => SeedCode(PriorityCodes), (SORPriority sp) => sp.PriorityCode);
 
-            ctx.Set<SORPriority>().AddRange(generator.GenerateList(100));
+            ctx.Set<SORPriority>().AddRange(generator.GenerateList(3));
             ctx.Set<SORPriority>().Add(new SORPriority
             {
                 Description = Priority,
@@ -191,7 +197,7 @@ namespace RepairsApi.Tests
                 .AddDefaultGenerators()
                 .AddGenerator(() => SeedCode(TradeCodes), (SorCodeTrade sct) => sct.Code);
 
-            ctx.Set<SorCodeTrade>().AddRange(generator.GenerateList(100));
+            ctx.Set<SorCodeTrade>().AddRange(generator.GenerateList(10));
 
             ctx.Set<SorCodeTrade>().Add(new SorCodeTrade
             {

--- a/RepairsApi.Tests/TestDataSeeder.cs
+++ b/RepairsApi.Tests/TestDataSeeder.cs
@@ -229,5 +229,29 @@ namespace RepairsApi.Tests
 
             return values[_rand.Next(values.Count)];
         }
+
+        internal static void AddCode(RepairsContext ctx, string expectedCode)
+        {
+            var generator = new Generator<ScheduleOfRates>()
+                .AddDefaultGenerators()
+                .AddValue(expectedCode, (ScheduleOfRates sor) => sor.Code)
+                .AddGenerator(() => PickCode(TradeCodes), (ScheduleOfRates sor) => sor.TradeCode)
+                .AddGenerator(() => PickCode(PriorityCodes), (ScheduleOfRates sor) => sor.PriorityId)
+                .AddValue(true, (ScheduleOfRates sor) => sor.Enabled)
+                .Ignore((ScheduleOfRates sor) => sor.Priority)
+                .Ignore((ScheduleOfRates sor) => sor.Trade)
+                .Ignore((ScheduleOfRates sor) => sor.SorCodeMap);
+
+            ctx.Set<ScheduleOfRates>().Add(generator.Generate());
+
+            ctx.Set<SORContract>().Add(new SORContract
+            {
+                ContractReference = ContractReference,
+                SorCodeCode = expectedCode,
+                Cost = 1
+            });
+
+            ctx.SaveChanges();
+        }
     }
 }

--- a/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
+++ b/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
@@ -71,14 +71,15 @@ namespace RepairsApi.Tests.V2.Controllers
         }
 
         [Test]
-        public async Task RaiseRepairReturnsOkWithInt()
+        [Ignore("Raise repair is not currently supported as it does not provide the relevant data for hackneys use cases")]
+        public void RaiseRepairReturnsOkWithInt()
         {
             // arrange
             const int newId = 2;
             _createWorkOrderUseCaseMock.Setup(m => m.Execute(It.IsAny<WorkOrder>())).ReturnsAsync(newId);
 
             // act
-            var result = await _classUnderTest.RaiseRepair(GenerateRaiseRepairRequest());
+            var result = _classUnderTest.RaiseRepair(GenerateRaiseRepairRequest());
 
             // assert
             result.Should().BeOfType<OkObjectResult>();
@@ -98,7 +99,8 @@ namespace RepairsApi.Tests.V2.Controllers
         }
 
         [Test]
-        public async Task RaiseRepairReturnsBadRequestWhenNotSupportedThrown()
+        [Ignore("Raise repair is not currently supported as it does not provide the relevant data for hackneys use cases")]
+        public void RaiseRepairReturnsBadRequestWhenNotSupportedThrown()
         {
             // arrange
             string expectedMessage = "message";
@@ -106,7 +108,7 @@ namespace RepairsApi.Tests.V2.Controllers
                 .ThrowsAsync(new NotSupportedException(expectedMessage));
 
             // act
-            var result = await _classUnderTest.RaiseRepair(GenerateRaiseRepairRequest());
+            var result = _classUnderTest.RaiseRepair(GenerateRaiseRepairRequest());
 
             // assert
             result.Should().BeOfType<BadRequestObjectResult>();

--- a/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
+++ b/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
@@ -14,7 +14,9 @@ using RepairsApi.V2.Infrastructure;
 using RepairsApi.V2.UseCase.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using RepairsApi.V2.Controllers.Parameters;
 using JobStatusUpdate = RepairsApi.V2.Generated.JobStatusUpdate;
 using WorkOrderComplete = RepairsApi.V2.Generated.WorkOrderComplete;
@@ -34,11 +36,15 @@ namespace RepairsApi.Tests.V2.Controllers
         private Mock<IGetWorkOrderUseCase> _getWorkOrderUseCase;
         private Mock<IListWorkOrderTasksUseCase> _listWorkOrderTasksUseCase;
         private Mock<IListWorkOrderNotesUseCase> _listWorkOrderNotesUseCase;
+        private Mock<IAuthorizationService> _authMock;
 
         [SetUp]
         public void SetUp()
         {
             ConfigureGenerator();
+            _authMock = new Mock<IAuthorizationService>();
+            _authMock.Setup(a => a.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<object>(), It.IsAny<string>()))
+                .ReturnsAsync(AuthorizationResult.Success());
             _createWorkOrderUseCaseMock = new Mock<ICreateWorkOrderUseCase>();
             _listWorkOrdersUseCase = new Mock<IListWorkOrdersUseCase>();
             _completeWorkOrderUseCase = new Mock<ICompleteWorkOrderUseCase>();
@@ -47,6 +53,7 @@ namespace RepairsApi.Tests.V2.Controllers
             _listWorkOrderTasksUseCase = new Mock<IListWorkOrderTasksUseCase>();
             _listWorkOrderNotesUseCase = new Mock<IListWorkOrderNotesUseCase>();
             _classUnderTest = new RepairsController(
+                _authMock.Object,
                 _createWorkOrderUseCaseMock.Object,
                 _listWorkOrdersUseCase.Object,
                 _completeWorkOrderUseCase.Object,

--- a/RepairsApi.Tests/V2/E2ETests/AppointmentApiTests.cs
+++ b/RepairsApi.Tests/V2/E2ETests/AppointmentApiTests.cs
@@ -52,14 +52,15 @@ namespace RepairsApi.Tests.V2.E2ETests
         private int AddWorkOrder()
         {
             int woRef = 0;
-            WithContext(ctx =>
+            using (var ctx = GetContext())
             {
-                var entry = ctx.WorkOrders.Add(new RepairsApi.V2.Infrastructure.WorkOrder());
+                var db = ctx.DB;
+                var entry = db.WorkOrders.Add(new RepairsApi.V2.Infrastructure.WorkOrder());
 
-                ctx.SaveChanges();
+                db.SaveChanges();
 
                 woRef = entry.Entity.Id;
-            });
+            };
             return woRef;
         }
 

--- a/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
+++ b/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
@@ -66,7 +66,7 @@ namespace RepairsApi.Tests.V2.E2ETests
             {
                 generator = GenerateWorkOrder<ScheduleRepair>()
                     .AddValue(new List<double> { 1 }, (RateScheduleItem rsi) => rsi.Quantity.Amount)
-                    .WithValidCodes(ctx.DB);
+                    .WithSorCodes(ctx.DB.SORCodes.Select(s => s.Code).ToArray());
             }
 
             var request = generator.Generate();
@@ -85,7 +85,8 @@ namespace RepairsApi.Tests.V2.E2ETests
             var client = CreateClient();
 
             Generator<ScheduleRepair> generator = GenerateWorkOrder<ScheduleRepair>()
-                .AddValue(new List<double>{ 1000 }, (RateScheduleItem rsi) => rsi.Quantity.Amount);
+                .AddValue(new List<double> { 1000 }, (RateScheduleItem rsi) => rsi.Quantity.Amount)
+                .AddValue(TestDataSeeder.SorCode, (RateScheduleItem rsi) => rsi.CustomCode);
 
             var request = generator.Generate();
             var serializedContent = JsonConvert.SerializeObject(request);
@@ -324,7 +325,7 @@ namespace RepairsApi.Tests.V2.E2ETests
                 gen = new Generator<T>()
                                 .AddWorkOrderGenerators()
                                 .AddValue(new List<double> { 0 }, (RateScheduleItem rsi) => rsi.Quantity.Amount)
-                                .WithValidCodes(db);
+                                .WithSorCodes(db.SORCodes.Select(s => s.Code).ToArray());
             };
 
             return gen;

--- a/RepairsApi.Tests/V2/Gateways/ScheduleOfRatesGatewayTests.cs
+++ b/RepairsApi.Tests/V2/Gateways/ScheduleOfRatesGatewayTests.cs
@@ -87,18 +87,26 @@ namespace RepairsApi.Tests.V2.Gateways
                 ContractorReference = "contractor",
                 ContractReference = "contract"
             };
+
+            ScheduleOfRates sor = new ScheduleOfRates
+            {
+                Code = "code",
+                Cost = 1,
+                Enabled = true,
+                LongDescription = "",
+            };
+
             generator
                 .AddDefaultGenerators()
-                .AddValue(null, (SORContract c) => c.SorCode)
+                .AddValue(sor, (SORContract c) => c.SorCode)
                 .AddValue(contract, (SORContract c) => c.Contract);
             var expectedContract = generator.Generate();
 
             await InMemoryDb.Instance.SORContracts.AddAsync(expectedContract);
-            await InMemoryDb.Instance.SORContracts.AddRangeAsync(generator.GenerateList(10));
             await InMemoryDb.Instance.SaveChangesAsync();
 
             // act
-            var result = await _classUnderTest.GetCost(contract.ContractorReference, expectedContract.SorCodeCode);
+            var result = await _classUnderTest.GetCost(contract.ContractorReference, sor.Code);
 
             // assert
             result.Should().Be(expectedContract.Cost);

--- a/RepairsApi.Tests/V2/Services/CurrentUserServiceTests.cs
+++ b/RepairsApi.Tests/V2/Services/CurrentUserServiceTests.cs
@@ -17,7 +17,9 @@ namespace RepairsApi.Tests.V2.Services
         {
             GroupOptions options = new GroupOptions
             {
-                SecurityGroups = new Dictionary<string, PermissionsModel>()
+                SecurityGroups = new Dictionary<string, PermissionsModel>(),
+                RaiseLimitGroups = new Dictionary<string, SpendLimitModel>(),
+                VaryLimitGroups = new Dictionary<string, SpendLimitModel>()
             };
             _classUnderTest = new CurrentUserService(new NullLogger<CurrentUserService>(), Options.Create(options));
         }

--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
@@ -27,12 +28,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using RepairsApi.V2.MiddleWare;
-using RepairsApi.V2.Services;
-using System.Security.Claims;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authorization;
-using RepairsApi.V2.Authorisation;
 
 namespace RepairsApi
 {

--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -62,8 +62,11 @@ namespace RepairsApi
             {
                 options.AddPolicy("RaiseSpendLimit", policy =>
                     policy.Requirements.Add(new RaiseLimitRequirement()));
+                options.AddPolicy("VarySpendLimit", policy =>
+                    policy.Requirements.Add(new VaryLimitRequirement()));
             });
-            services.AddSingleton<IAuthorizationHandler, SpendLimitAuthorizationHandler>();
+            services.AddSingleton<IAuthorizationHandler, RaiseSpendLimitAuthorizationHandler>();
+            services.AddSingleton<IAuthorizationHandler, VarySpendLimitAuthorizationHandler>();
 
             services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();
 

--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -65,8 +65,8 @@ namespace RepairsApi
                 options.AddPolicy("VarySpendLimit", policy =>
                     policy.Requirements.Add(new VaryLimitRequirement()));
             });
-            services.AddSingleton<IAuthorizationHandler, RaiseSpendLimitAuthorizationHandler>();
-            services.AddSingleton<IAuthorizationHandler, VarySpendLimitAuthorizationHandler>();
+            services.AddScoped<IAuthorizationHandler, RaiseSpendLimitAuthorizationHandler>();
+            services.AddScoped<IAuthorizationHandler, VarySpendLimitAuthorizationHandler>();
 
             services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();
 

--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -23,9 +23,9 @@ using RepairsApi.V2.UseCase;
 using RepairsApi.V2.UseCase.JobStatusUpdatesUseCases;
 using RepairsApi.V2.MiddleWare;
 using RepairsApi.V2.Services;
-using Microsoft.AspNetCore.Authorization;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
 using RepairsApi.V2.Authorisation;
 
 namespace RepairsApi
@@ -58,7 +58,12 @@ namespace RepairsApi
                 o.ApiVersionReader = new UrlSegmentApiVersionReader(); // read the version number from the url segment header)
             });
 
-            services.AddAuthorization();
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("RaiseSpendLimit", policy =>
+                    policy.Requirements.Add(new RaiseLimitRequirement()));
+            });
+            services.AddSingleton<IAuthorizationHandler, SpendLimitAuthorizationHandler>();
 
             services.AddSingleton<IApiVersionDescriptionProvider, DefaultApiVersionDescriptionProvider>();
 
@@ -237,4 +242,5 @@ namespace RepairsApi
             });
         }
     }
+
 }

--- a/RepairsApi/V2/Authorisation/CustomClaimTypes.cs
+++ b/RepairsApi/V2/Authorisation/CustomClaimTypes.cs
@@ -3,5 +3,6 @@ namespace RepairsApi.V2.Authorisation
     public static class CustomClaimTypes
     {
         public const string CONTRACTOR = "contractor";
+        public const string RAISELIMIT = "raiselimit";
     }
 }

--- a/RepairsApi/V2/Authorisation/CustomClaimTypes.cs
+++ b/RepairsApi/V2/Authorisation/CustomClaimTypes.cs
@@ -4,5 +4,6 @@ namespace RepairsApi.V2.Authorisation
     {
         public const string CONTRACTOR = "contractor";
         public const string RAISELIMIT = "raiselimit";
+        public const string VARYLIMIT = "varylimit";
     }
 }

--- a/RepairsApi/V2/Authorisation/Groups.cs
+++ b/RepairsApi/V2/Authorisation/Groups.cs
@@ -12,6 +12,12 @@ namespace RepairsApi.V2.Authorisation
             { "repairs-hub-frontend-staging-contractors-alphatrack", (SecurityGroup.CONTRACTOR, "ASL") },
             { "repairs-hub-frontend-staging-contractors-purdy", (SecurityGroup.CONTRACTOR, "PCL") },
         };
+
+        public static readonly Dictionary<string, double> RaiseLimitGroups = new Dictionary<string, double>
+        {
+            { "repairs-hub-frontend-staging-limit50", 50 },
+            { "repairs-hub-frontend-staging-limit150", 150 },
+        };
     }
 
     public static class SecurityGroup

--- a/RepairsApi/V2/Authorisation/Groups.cs
+++ b/RepairsApi/V2/Authorisation/Groups.cs
@@ -4,22 +4,30 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace RepairsApi.V2.Authorisation
 {
-    public static class Groups
+
+    public interface IGroups
     {
-        public static readonly Dictionary<string, PermissionsModel> SecurityGroups = new Dictionary<string, PermissionsModel>
+        Dictionary<string, PermissionsModel> SecurityGroups { get; }
+        Dictionary<string, double> RaiseLimitGroups { get; }
+        Dictionary<string, double> VaryLimitGroups { get; }
+    }
+
+    public class Groups : IGroups
+    {
+        public Dictionary<string, PermissionsModel> SecurityGroups { get; } = new Dictionary<string, PermissionsModel>
         {
             { "repairs-hub-frontend-staging", (SecurityGroup.AGENT, null) },
             { "repairs-hub-frontend-staging-contractors-alphatrack", (SecurityGroup.CONTRACTOR, "ASL") },
             { "repairs-hub-frontend-staging-contractors-purdy", (SecurityGroup.CONTRACTOR, "PCL") },
         };
 
-        public static readonly Dictionary<string, double> RaiseLimitGroups = new Dictionary<string, double>
+        public Dictionary<string, double> RaiseLimitGroups { get; } = new Dictionary<string, double>
         {
             { "repairs-hub-frontend-staging-raiselimit50", 50 },
             { "repairs-hub-frontend-staging-raiselimit150", 150 },
         };
 
-        public static readonly Dictionary<string, double> VaryLimitGroups = new Dictionary<string, double>
+        public Dictionary<string, double> VaryLimitGroups { get; } = new Dictionary<string, double>
         {
             { "repairs-hub-frontend-staging-varylimit50", 50 },
             { "repairs-hub-frontend-staging-varylimit150", 150 },

--- a/RepairsApi/V2/Authorisation/Groups.cs
+++ b/RepairsApi/V2/Authorisation/Groups.cs
@@ -15,8 +15,14 @@ namespace RepairsApi.V2.Authorisation
 
         public static readonly Dictionary<string, double> RaiseLimitGroups = new Dictionary<string, double>
         {
-            { "repairs-hub-frontend-staging-limit50", 50 },
-            { "repairs-hub-frontend-staging-limit150", 150 },
+            { "repairs-hub-frontend-staging-raiselimit50", 50 },
+            { "repairs-hub-frontend-staging-raiselimit150", 150 },
+        };
+
+        public static readonly Dictionary<string, double> VaryLimitGroups = new Dictionary<string, double>
+        {
+            { "repairs-hub-frontend-staging-varylimit50", 50 },
+            { "repairs-hub-frontend-staging-varylimit150", 150 },
         };
     }
 

--- a/RepairsApi/V2/Authorisation/Groups.cs
+++ b/RepairsApi/V2/Authorisation/Groups.cs
@@ -7,6 +7,8 @@ namespace RepairsApi.V2.Authorisation
     public class GroupOptions
     {
         public Dictionary<string, PermissionsModel> SecurityGroups { get; set; }
+        public Dictionary<string, SpendLimitModel> RaiseLimitGroups { get; set; }
+        public Dictionary<string, SpendLimitModel> VaryLimitGroups { get; set; }
 
         public override string ToString()
         {
@@ -24,5 +26,10 @@ namespace RepairsApi.V2.Authorisation
     {
         public string SecurityGroup { get; set; }
         public string ContractorReference { get; set; }
+    }
+
+    public class SpendLimitModel
+    {
+        public double Limit { get; set; }
     }
 }

--- a/RepairsApi/V2/Authorisation/RaiseLimitRequirement.cs
+++ b/RepairsApi/V2/Authorisation/RaiseLimitRequirement.cs
@@ -32,9 +32,9 @@ namespace RepairsApi.V2.Authorisation
             var contractorRef = resource.AssignedToPrimary.Reference?.FirstOrDefault()?.ID;
             var rawCodes = resource.WorkElement
                 .SelectMany(we => we.RateScheduleItem)
-                .Select(rsi => (code: rsi.CustomCode, amount: rsi.Quantity.Amount.Sum()));
+                .Select(rsi => new { rsi.CustomCode, Amount = rsi.Quantity.Amount.Sum() });
             double totalCost = 0;
-            await rawCodes.ForEachAsync(async c => totalCost += c.amount * await _sorGateway.GetCost(contractorRef, c.code) ?? 0);
+            await rawCodes.ForEachAsync(async c => totalCost += c.Amount * await _sorGateway.GetCost(contractorRef, c.CustomCode) ?? 0);
 
             var limit = double.Parse(context.User.FindFirst(CustomClaimTypes.RAISELIMIT).Value);
 

--- a/RepairsApi/V2/Authorisation/RaiseLimitRequirement.cs
+++ b/RepairsApi/V2/Authorisation/RaiseLimitRequirement.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using RepairsApi.V2.Domain;
+using RepairsApi.V2.Gateways;
+using RepairsApi.V2.Generated;
+
+namespace RepairsApi.V2.Authorisation
+{
+    public class RaiseLimitRequirement : IAuthorizationRequirement
+    {
+    }
+
+    public class SpendLimitAuthorizationHandler :
+        AuthorizationHandler<RaiseLimitRequirement, (ICollection<WorkElement> codes,string contrctorRef)>
+    {
+        private readonly IScheduleOfRatesGateway _sorGateway;
+
+        public SpendLimitAuthorizationHandler(IScheduleOfRatesGateway sorGateway)
+        {
+            _sorGateway = sorGateway;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            RaiseLimitRequirement requirement,
+            (ICollection<WorkElement> codes,string contrctorRef) resource
+            )
+        {
+            var rawCodes = resource.codes
+                .SelectMany(we => we.RateScheduleItem)
+                .Select(rsi => (code: rsi.CustomCode, amount: rsi.Quantity.Amount.Sum()));
+            double totalCost = 0;
+            await rawCodes.ForEachAsync(async c => totalCost += c.amount * await _sorGateway.GetCost(resource.contrctorRef, c.code) ?? 0);
+
+            var limit = double.Parse(context.User.FindFirst(CustomClaimTypes.RAISELIMIT).Value);
+
+            if (totalCost <= limit)
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/RepairsApi/V2/Authorisation/RaiseLimitRequirement.cs
+++ b/RepairsApi/V2/Authorisation/RaiseLimitRequirement.cs
@@ -34,7 +34,7 @@ namespace RepairsApi.V2.Authorisation
                 .SelectMany(we => we.RateScheduleItem)
                 .Select(rsi => new { rsi.CustomCode, Amount = rsi.Quantity.Amount.Sum() });
             double totalCost = 0;
-            await rawCodes.ForEachAsync(async c => totalCost += c.Amount * await _sorGateway.GetCost(contractorRef, c.CustomCode) ?? 0);
+            await rawCodes.ForEachAsync(async c => totalCost += c.Amount * await _sorGateway.GetCost(contractorRef, c.CustomCode));
 
             var limit = double.Parse(context.User.FindFirst(CustomClaimTypes.RAISELIMIT).Value);
 

--- a/RepairsApi/V2/Authorisation/VaryLimitRequirement.cs
+++ b/RepairsApi/V2/Authorisation/VaryLimitRequirement.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using RepairsApi.V2.Domain;
+using RepairsApi.V2.Gateways;
+using RepairsApi.V2.Generated;
+
+namespace RepairsApi.V2.Authorisation
+{
+    public class VaryLimitRequirement : IAuthorizationRequirement
+    {
+    }
+
+    public class VarySpendLimitAuthorizationHandler :
+        AuthorizationHandler<VaryLimitRequirement, JobStatusUpdate>
+    {
+        private readonly IScheduleOfRatesGateway _sorGateway;
+        private readonly IRepairsGateway _repairsGateway;
+
+        public VarySpendLimitAuthorizationHandler(
+            IScheduleOfRatesGateway sorGateway,
+            IRepairsGateway repairsGateway
+            )
+        {
+            _sorGateway = sorGateway;
+            _repairsGateway = repairsGateway;
+        }
+
+        protected override async Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            VaryLimitRequirement requirement,
+            JobStatusUpdate resource
+            )
+        {
+            var workOrderId = int.Parse(resource.RelatedWorkOrderReference.ID);
+            var workOrder = await _repairsGateway.GetWorkOrder(workOrderId);
+            var contractorRef = workOrder.AssignedToPrimary.ContractorReference;
+
+            var rawCodes = resource.MoreSpecificSORCode.RateScheduleItem
+                .Select(rsi => (code: rsi.CustomCode, amount: rsi.Quantity.Amount.Sum())).ToList();
+
+            rawCodes.AddRange(workOrder.WorkElements
+                .SelectMany(we => we.RateScheduleItem)
+                .Where(rsi => !rsi.Original)
+                .Select(rsi => (code: rsi.CustomCode, amount: rsi.Quantity.Amount)));
+
+            double totalCost = 0;
+            await rawCodes.ForEachAsync(async c => totalCost += c.amount * await _sorGateway.GetCost(contractorRef, c.code) ?? 0);
+
+            var limit = double.Parse(context.User.FindFirst(CustomClaimTypes.RAISELIMIT).Value);
+
+            if (totalCost <= limit)
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/RepairsApi/V2/Controllers/RepairsController.cs
+++ b/RepairsApi/V2/Controllers/RepairsController.cs
@@ -90,7 +90,7 @@ namespace RepairsApi.V2.Controllers
         {
             try
             {
-                var authorised = await _authorizationService.AuthorizeAsync(User, (request.WorkElement, request.AssignedToPrimary.Reference?.FirstOrDefault()?.ID), "RaiseSpendLimit");
+                var authorised = await _authorizationService.AuthorizeAsync(User, request, "RaiseSpendLimit");
                 if (!authorised.Succeeded) return Unauthorized("Request Work Order is above Spend Limit");
 
                 var result = await _createWorkOrderUseCase.Execute(request.ToDb());
@@ -169,6 +169,9 @@ namespace RepairsApi.V2.Controllers
         [ProducesDefaultResponseType]
         public async Task<IActionResult> JobStatusUpdate([FromBody] JobStatusUpdate request)
         {
+            var authorised = await _authorizationService.AuthorizeAsync(User, request, "VarySpendLimit");
+            if (!authorised.Succeeded) return Unauthorized("Resulting Work Order is above Spend Limit");
+
             await _updateJobStatusUseCase.Execute(request);
             return Ok();
         }

--- a/RepairsApi/V2/Controllers/RepairsController.cs
+++ b/RepairsApi/V2/Controllers/RepairsController.cs
@@ -52,7 +52,7 @@ namespace RepairsApi.V2.Controllers
         }
 
         /// <summary>
-        /// Raise a repair (creates a work order)
+        /// Raise a repair (creates a work order) [CURRENTLY UNSUPPORTED]
         /// </summary>
         /// <param name="request"></param>
         /// <returns></returns>
@@ -61,17 +61,18 @@ namespace RepairsApi.V2.Controllers
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesDefaultResponseType]
         [Authorize(Roles = SecurityGroup.AGENT)]
-        public async Task<IActionResult> RaiseRepair([FromBody] RaiseRepair request)
+        public IActionResult RaiseRepair([FromBody] RaiseRepair request)
         {
-            try
-            {
-                var result = await _createWorkOrderUseCase.Execute(request.ToDb());
-                return Ok(result);
-            }
-            catch (NotSupportedException e)
-            {
-                return BadRequest(e.Message);
-            }
+            throw new NotSupportedException("migrate to schedule repair");
+            //try
+            //{
+            //    var result = await _createWorkOrderUseCase.Execute(request.ToDb());
+            //    return Ok(result);
+            //}
+            //catch (NotSupportedException e)
+            //{
+            //    return BadRequest(e.Message);
+            //}
         }
 
 

--- a/RepairsApi/V2/Gateways/IScheduleOfRatesGateway.cs
+++ b/RepairsApi/V2/Gateways/IScheduleOfRatesGateway.cs
@@ -13,7 +13,7 @@ namespace RepairsApi.V2.Gateways
     {
         Task<IEnumerable<SorCodeTrade>> GetTrades(string propRef);
         Task<IEnumerable<ScheduleOfRatesModel>> GetSorCodes(string propertyReference, string tradeCode, string contractorReference);
-        Task<double?> GetCost(string contractReference, string sorCode);
+        Task<double> GetCost(string contractReference, string sorCode);
         Task<IEnumerable<string>> GetContracts(string contractorReference);
         Task<IEnumerable<ScheduleOfRatesModel>> GetSorCodes();
         Task<IEnumerable<Contractor>> GetContractors(string propertyRef, string tradeCode);

--- a/RepairsApi/V2/Gateways/ScheduleOfRatesGateway.cs
+++ b/RepairsApi/V2/Gateways/ScheduleOfRatesGateway.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using RepairsApi.V2.Factories;
 using Contractor = RepairsApi.V2.Domain.Contractor;
+using RepairsApi.V2.Exceptions;
 
 namespace RepairsApi.V2.Gateways
 {
@@ -67,13 +68,19 @@ namespace RepairsApi.V2.Gateways
             ).ToListAsync();
         }
 
-        public async Task<double?> GetCost(string contractorReference, string sorCode)
+        public async Task<double> GetCost(string contractorReference, string sorCode)
         {
-            if (contractorReference is null || sorCode is null) return null;
+            if (contractorReference is null) throw new ArgumentNullException(contractorReference);
+            if (sorCode is null) throw new ArgumentNullException(sorCode);
 
-            return await _context.SORContracts
-                .Where(c => c.Contract.ContractorReference == contractorReference && c.SorCodeCode == sorCode)
-                .Select(c => c.Cost).SingleOrDefaultAsync();
+            var costs = await _context.SORContracts
+                            .Where(c => c.Contract.ContractorReference == contractorReference && c.SorCodeCode == sorCode)
+                            .Select(c => new { ContractCost = c.Cost, CodeCost = c.SorCode.Cost }).SingleOrDefaultAsync();
+            double? finalCost = costs.ContractCost ?? costs.CodeCost;
+
+            if (!finalCost.HasValue) throw new ResourceNotFoundException($"Cannot find cost for code {sorCode}");
+
+            return finalCost.Value;
         }
 
         public async Task<IEnumerable<string>> GetContracts(string contractorReference)

--- a/RepairsApi/V2/Gateways/ScheduleOfRatesGateway.cs
+++ b/RepairsApi/V2/Gateways/ScheduleOfRatesGateway.cs
@@ -70,13 +70,13 @@ namespace RepairsApi.V2.Gateways
 
         public async Task<double> GetCost(string contractorReference, string sorCode)
         {
-            if (contractorReference is null) throw new ArgumentNullException(contractorReference);
-            if (sorCode is null) throw new ArgumentNullException(sorCode);
+            if (contractorReference is null) throw new ArgumentNullException(nameof(contractorReference));
+            if (sorCode is null) throw new ArgumentNullException(nameof(sorCode));
 
             var costs = await _context.SORContracts
                             .Where(c => c.Contract.ContractorReference == contractorReference && c.SorCodeCode == sorCode)
                             .Select(c => new { ContractCost = c.Cost, CodeCost = c.SorCode.Cost }).SingleOrDefaultAsync();
-            double? finalCost = costs.ContractCost ?? costs.CodeCost;
+            double? finalCost = costs?.ContractCost ?? costs?.CodeCost;
 
             if (!finalCost.HasValue) throw new ResourceNotFoundException($"Cannot find cost for code {sorCode}");
 

--- a/RepairsApi/V2/Infrastructure/Hackney/ScheduleOfRates.cs
+++ b/RepairsApi/V2/Infrastructure/Hackney/ScheduleOfRates.cs
@@ -67,7 +67,7 @@ namespace RepairsApi.V2.Infrastructure.Hackney
         [Required]
         public virtual ScheduleOfRates SorCode { get; set; }
         public string SorCodeCode { get; set; }
-        public double Cost { get; set; }
+        public double? Cost { get; set; }
 
         [Required]
         public virtual Contract Contract { get; set; }

--- a/RepairsApi/V2/Infrastructure/TransactionManager.cs
+++ b/RepairsApi/V2/Infrastructure/TransactionManager.cs
@@ -33,7 +33,7 @@ namespace RepairsApi.V2.Infrastructure
 
     public class Transaction : ITransaction
     {
-        private IDbContextTransaction _transaction;
+        private readonly IDbContextTransaction _transaction;
         private bool _commited;
 
         public Transaction(IDbContextTransaction transaction)

--- a/RepairsApi/V2/Services/CurrentUserService.cs
+++ b/RepairsApi/V2/Services/CurrentUserService.cs
@@ -69,6 +69,7 @@ namespace RepairsApi.V2.Services
             identity.AddClaim(new Claim(ClaimTypes.Name, user.Name));
 
             var raiseLimit = 0.0;
+            var varyLimit = 0.0;
 
             foreach (var group in user.Groups)
             {
@@ -82,13 +83,19 @@ namespace RepairsApi.V2.Services
                     }
                 }
 
-                if (Groups.RaiseLimitGroups.TryGetValue(group, out double limit))
+                if (_options.RaiseLimitGroups.TryGetValue(group, out SpendLimitModel? newRaiseLimit))
                 {
-                    raiseLimit = Math.Max(raiseLimit, limit);
+                    raiseLimit = Math.Max(raiseLimit, newRaiseLimit.Limit);
+                }
+
+                if (_options.VaryLimitGroups.TryGetValue(group, out SpendLimitModel? newVaryLimit))
+                {
+                    varyLimit = Math.Max(varyLimit, newVaryLimit.Limit);
                 }
             }
 
             identity.AddClaim(new Claim(CustomClaimTypes.RAISELIMIT, raiseLimit.ToString(CultureInfo.InvariantCulture)));
+            identity.AddClaim(new Claim(CustomClaimTypes.VARYLIMIT, varyLimit.ToString(CultureInfo.InvariantCulture)));
 
             return new ClaimsPrincipal(identity);
         }

--- a/RepairsApi/appsettings.IntegrationTests.json
+++ b/RepairsApi/appsettings.IntegrationTests.json
@@ -24,6 +24,28 @@
         "SecurityGroup": "contractor",
         "ContractorReference": "contractor"
       }
+    },
+    "RaiseLimitGroups": {
+      "raise50": {
+        "Limit": 50
+      },
+      "raise100": {
+        "Limit": 100
+      },
+      "raise150": {
+        "Limit": 150
+      }
+    },
+    "VaryLimitGroups": {
+      "vary50": {
+        "Limit": 50
+      },
+      "vary100": {
+        "Limit": 100
+      },
+      "vary150": {
+        "Limit": 150
+      }
     }
   }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://trello.com/c/nUbGrRug/383-enforce-spend-limit-when-varying

## Describe this PR

### *What is the problem we're trying to solve*

Agents and contractors Cannot raise or vary work orders above their alloted spend limits. these are defined and mapped from google groups configured within the application

### *What changes have we introduced*

2 new authorisation policies for raising and varying spend limits

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly
