### PR TITLE
Added ids and fixed security to work order

### DIFF
--- a/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
+++ b/RepairsApi.Tests/V2/Controllers/RepairsControllerTests.cs
@@ -229,7 +229,7 @@ namespace RepairsApi.Tests.V2.Controllers
 
             response.AssertForEach(expected, (vm, domain) =>
             {
-                vm.Code.Should().Be(domain.Id);
+                vm.Code.Should().Be(domain.Code);
                 vm.Cost.Should().Be(domain.Cost);
                 vm.DateAdded.Should().Be(domain.DateAdded);
                 vm.Description.Should().Be(domain.Description);

--- a/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
+++ b/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
@@ -21,6 +21,7 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 using Quantity = RepairsApi.V2.Generated.Quantity;
 using RateScheduleItem = RepairsApi.V2.Generated.RateScheduleItem;
 using WorkOrderComplete = RepairsApi.V2.Generated.WorkOrderComplete;
+using RepairsApi.V2.Factories;
 
 namespace RepairsApi.Tests.V2.E2ETests
 {
@@ -238,9 +239,12 @@ namespace RepairsApi.Tests.V2.E2ETests
             var serializedContent = JsonConvert.SerializeObject(request);
             StringContent content = new StringContent(serializedContent, Encoding.UTF8, "application/json");
 
-            var workOrderId = await ValidateWorkOrderCreation(client, content, null, endpoint);
-
             var workElement = request.WorkElement.First();
+            var workOrderId = await ValidateWorkOrderCreation(client, content, wo =>
+            {
+                workElement.RateScheduleItem = wo.WorkElements.First().RateScheduleItem.Select(rsi => rsi.ToResponse()).ToList();
+            }, endpoint);
+
             var expectedNewCode = new RateScheduleItem
             {
                 CustomCode = expectedCode,

--- a/RepairsApi.Tests/V2/UseCase/ListWorkOrderTasksUseCaseTest.cs
+++ b/RepairsApi.Tests/V2/UseCase/ListWorkOrderTasksUseCaseTest.cs
@@ -61,7 +61,7 @@ namespace RepairsApi.Tests.V2.UseCase
             result.Description.Should().Be(expected.CustomName);
             result.Quantity.Should().Be(expected.Quantity?.Amount ?? 0);
             result.Cost.Should().Be(expected.CodeCost);
-            result.Id.Should().Be(expected.CustomCode);
+            result.Code.Should().Be(expected.CustomCode);
             result.Status.Should().Be("Unknown");
             result.DateAdded.Should().Be(expected.DateCreated.GetValueOrDefault());
             result.Original.Should().Be(expected.Original);

--- a/RepairsApi/V2/Boundary/Response/WorkOrderItemViewModel.cs
+++ b/RepairsApi/V2/Boundary/Response/WorkOrderItemViewModel.cs
@@ -4,6 +4,7 @@ namespace RepairsApi.V2.Boundary.Response
 {
     public class WorkOrderItemViewModel
     {
+        public string Id { get; set; }
         public string Code { get; set; }
         public string Description { get; set; }
         public DateTime? DateAdded { get; set; }

--- a/RepairsApi/V2/Controllers/RepairsController.cs
+++ b/RepairsApi/V2/Controllers/RepairsController.cs
@@ -172,13 +172,9 @@ namespace RepairsApi.V2.Controllers
         [ProducesResponseType(typeof(string), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(string), StatusCodes.Status404NotFound)]
         [ProducesDefaultResponseType]
-        [Authorize(Roles = UserGroups.CONTRACTOR)]
 
         public async Task<IActionResult> JobStatusUpdate([FromBody] JobStatusUpdate request)
         {
-            var authorised = await _authorizationService.AuthorizeAsync(User, request, "VarySpendLimit");
-            if (await _featureManager.IsEnabledAsync(FeatureFlags.SPENDLIMITS) && !authorised.Succeeded) return Unauthorized("Resulting Work Order is above Spend Limit");
-
             await _updateJobStatusUseCase.Execute(request);
             return Ok();
         }

--- a/RepairsApi/V2/Domain/WorkOrderTask.cs
+++ b/RepairsApi/V2/Domain/WorkOrderTask.cs
@@ -5,11 +5,12 @@ namespace RepairsApi.V2.Domain
     public class WorkOrderTask
     {
         public double Quantity { get; internal set; }
-        public string Id { get; internal set; }
+        public string Code { get; internal set; }
         public double? Cost { get; internal set; }
         public DateTime? DateAdded { get; internal set; }
         public string Description { get; internal set; }
         public string Status { get; internal set; }
         public bool Original { get; set; }
+        public Guid Id { get; set; }
     }
 }

--- a/RepairsApi/V2/Factories/DBModelFactory.cs
+++ b/RepairsApi/V2/Factories/DBModelFactory.cs
@@ -237,25 +237,33 @@ namespace RepairsApi.V2.Factories
             };
         }
 
-        public static WorkElement ToDb(this Generated.WorkElement raiseRepair)
+        public static WorkElement ToDb(this Generated.WorkElement raiseRepair, bool mapIds = false)
         {
             return new WorkElement
             {
                 ContainsCapitalWork = raiseRepair.ContainsCapitalWork,
                 ServiceChargeSubject = raiseRepair.ServiceChargeSubject,
                 Trade = raiseRepair.Trade.MapList(t => t.ToDb()),
-                RateScheduleItem = raiseRepair.RateScheduleItem.MapList(rsi => rsi.ToDb())
+                RateScheduleItem = raiseRepair.RateScheduleItem.MapList(rsi => rsi.ToDb(mapIds))
             };
         }
 
-        public static RateScheduleItem ToDb(this Generated.RateScheduleItem raiseRepair)
+        public static RateScheduleItem ToDb(this Generated.RateScheduleItem raiseRepair, bool mapIds = false)
         {
-            return new RateScheduleItem
+            RateScheduleItem rateScheduleItem = new RateScheduleItem
             {
                 CustomCode = raiseRepair.CustomCode,
                 CustomName = raiseRepair.CustomName,
                 Quantity = raiseRepair.Quantity?.ToDb(),
+                DateCreated = DateTime.UtcNow
             };
+
+            if (mapIds && Guid.TryParse(raiseRepair.Id, out var id))
+            {
+                rateScheduleItem.Id = id;
+            }
+
+            return rateScheduleItem;
         }
 
         public static Quantity ToDb(this Generated.Quantity raiseRepair)
@@ -492,12 +500,10 @@ namespace RepairsApi.V2.Factories
 
         public static JobStatusUpdate ToDb(
             this Generated.JobStatusUpdate jobStatusUpdate,
-            IEnumerable<WorkElement> workElements,
             WorkOrder workOrder)
         {
             return new JobStatusUpdate
             {
-                RelatedWorkElement = workElements.ToList(),
                 EventTime = DateTime.Now,
                 TypeCode = jobStatusUpdate.TypeCode,
                 AdditionalWork = jobStatusUpdate.AdditionalWork?.ToDb(),

--- a/RepairsApi/V2/Factories/ResponseFactory.cs
+++ b/RepairsApi/V2/Factories/ResponseFactory.cs
@@ -215,7 +215,8 @@ namespace RepairsApi.V2.Factories
                 Quantity = rateScheduleItem.Quantity.ToResponse(),
                 CustomCode = rateScheduleItem.CustomCode,
                 CustomName = rateScheduleItem.CustomName,
-                M3NHFSORCode = rateScheduleItem.M3NHFSORCode
+                M3NHFSORCode = rateScheduleItem.M3NHFSORCode,
+                Id = rateScheduleItem.Id.ToString()
             };
         }
 
@@ -240,8 +241,9 @@ namespace RepairsApi.V2.Factories
         {
             return new WorkOrderItemViewModel
             {
+                Id = domain.Id.ToString(),
                 Quantity = domain.Quantity,
-                Code = domain.Id,
+                Code = domain.Code,
                 Cost = domain.Cost,
                 DateAdded = domain.DateAdded,
                 Description = domain.Description,

--- a/RepairsApi/V2/Gateways/IRepairsGateway.cs
+++ b/RepairsApi/V2/Gateways/IRepairsGateway.cs
@@ -15,5 +15,6 @@ namespace RepairsApi.V2.Gateways
         Task<IEnumerable<WorkElement>> GetWorkElementsForWorkOrder(WorkOrder workOrder);
         Task<IEnumerable<WorkElement>> GetWorkElementsForWorkOrder(int id);
         Task UpdateWorkOrderStatus(int workOrderId, WorkStatusCode canceled);
+        Task SaveChangesAsync();
     }
 }

--- a/RepairsApi/V2/Gateways/RepairsGateway.cs
+++ b/RepairsApi/V2/Gateways/RepairsGateway.cs
@@ -92,6 +92,11 @@ namespace RepairsApi.V2.Gateways
             order.StatusCode = newCode;
             await _repairsContext.SaveChangesAsync();
         }
+
+        public Task SaveChangesAsync()
+        {
+            return _repairsContext.SaveChangesAsync();
+        }
     }
 
     public static class WorkOrderExtensions

--- a/RepairsApi/V2/Generated/Extensions/WorkOrderExtensions.cs
+++ b/RepairsApi/V2/Generated/Extensions/WorkOrderExtensions.cs
@@ -11,4 +11,10 @@ namespace RepairsApi.V2.Generated
         [Newtonsoft.Json.JsonProperty("NumberOfDays", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? NumberOfDays { get; set; }
     }
+
+    public partial class RateScheduleItem
+    {
+        [Newtonsoft.Json.JsonProperty("Id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Id { get; set; }
+    }
 }

--- a/RepairsApi/V2/MiddleWare/ExceptionMiddleware.cs
+++ b/RepairsApi/V2/MiddleWare/ExceptionMiddleware.cs
@@ -46,12 +46,10 @@ namespace RepairsApi.V2.MiddleWare
     {
         public static async Task SetResponse(this HttpContext httpContext, int code, string message)
         {
-            using (var writer = new StreamWriter(httpContext.Response.Body))
-            {
-                httpContext.Response.StatusCode = code;
-                await writer.WriteAsync(message);
-                await writer.FlushAsync();
-            }
+            using var writer = new StreamWriter(httpContext.Response.Body);
+            httpContext.Response.StatusCode = code;
+            await writer.WriteAsync(message);
+            await writer.FlushAsync();
         }
     }
 }

--- a/RepairsApi/V2/UseCase/CreateWorkOrderUseCase.cs
+++ b/RepairsApi/V2/UseCase/CreateWorkOrderUseCase.cs
@@ -66,7 +66,6 @@ namespace RepairsApi.V2.UseCase
             {
                 await element.RateScheduleItem.ForEachAsync(async item =>
                 {
-                    item.DateCreated = DateTime.UtcNow;
                     item.CodeCost = await GetCost(workOrder.AssignedToPrimary?.ContractorReference, item.CustomCode);
                     item.Original = true;
                     item.OriginalQuantity = item.Quantity.Amount;

--- a/RepairsApi/V2/UseCase/ListWorkOrderTasksUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrderTasksUseCase.cs
@@ -29,10 +29,11 @@ namespace RepairsApi.V2.UseCase
 
                 return new WorkOrderTask
                 {
+                    Id = rsi.Id,
                     Description = rsi.CustomName,
                     Quantity = quantity,
                     Cost = rsi.CodeCost,
-                    Id = rsi.CustomCode,
+                    Code = rsi.CustomCode,
                     Status = "Unknown",
                     DateAdded = rsi.DateCreated.GetValueOrDefault()
                 };

--- a/RepairsApi/V2/UseCase/UpdateJobStatusUseCase.cs
+++ b/RepairsApi/V2/UseCase/UpdateJobStatusUseCase.cs
@@ -35,11 +35,9 @@ namespace RepairsApi.V2.UseCase
 
             var workOrder = await _repairsGateway.GetWorkOrder(workOrderId);
 
-            var workElements = await _repairsGateway.GetWorkElementsForWorkOrder(workOrder);
-
             await _strategyFactory.ProcessActions(jobStatusUpdate);
 
-            await _jobStatusUpdateGateway.CreateJobStatusUpdate(jobStatusUpdate.ToDb(workElements, workOrder));
+            await _jobStatusUpdateGateway.CreateJobStatusUpdate(jobStatusUpdate.ToDb(workOrder));
         }
 
     }


### PR DESCRIPTION
This PR moves the update of sor codes auhorisation check later so its only executed for that particular type of update.
It also adds a UID for rate schedule items so that duplicate items with the sor code on variation.

This needs to be lined up with f/e work to receive the new ids and pass them on when performing an update of the sor codes 