### PR TITLE
Fix nested contact info in PropertyResponse

### DIFF
--- a/RepairsApi/V2/Boundary/Response/PropertyResponse.cs
+++ b/RepairsApi/V2/Boundary/Response/PropertyResponse.cs
@@ -22,11 +22,6 @@ namespace RepairsApi.V2.Boundary.Response
         /// <summary>
         /// Gets or Sets Resident Contact Information
         /// </summary>
-        public ResidentContactsViewModel Contacts { get; set; }
-    }
-
-    public class ResidentContactsViewModel
-    {
         public IEnumerable<ResidentContactViewModel> Contacts { get; set; }
     }
 

--- a/RepairsApi/V2/Factories/ResponseFactory.cs
+++ b/RepairsApi/V2/Factories/ResponseFactory.cs
@@ -91,12 +91,9 @@ namespace RepairsApi.V2.Factories
             };
         }
 
-        public static ResidentContactsViewModel ToResponse(this IEnumerable<ResidentContact> domain)
+        public static IEnumerable<ResidentContactViewModel> ToResponse(this IEnumerable<ResidentContact> domain)
         {
-            return new ResidentContactsViewModel
-            {
-                Contacts = domain.MapList(contact => contact.ToResponse())
-            };
+            return new List<ResidentContactViewModel>(domain.Select(contact => contact.ToResponse()));
         }
 
         public static ResidentContactViewModel ToResponse(this ResidentContact domain)


### PR DESCRIPTION
Contacts object was nested in PropertyResponse - it doesn't need to be.