### PR TITLE
Allow filtering by work order status

### DIFF
--- a/RepairsApi.Tests/V2/Gateways/RepairGatewayTests.cs
+++ b/RepairsApi.Tests/V2/Gateways/RepairGatewayTests.cs
@@ -95,6 +95,23 @@ namespace RepairsApi.Tests.V2.Gateways
         }
 
         [Test]
+        public async Task CanGetWorkOrdersFilteredByStatus()
+        {
+            // arrange
+            await InMemoryDb.Instance.WorkOrders.AddRangeAsync(CreateWorkOrders(25));
+            var expectedWorkOrder = CreateWorkOrderWithStatus(70);
+            await InMemoryDb.Instance.WorkOrders.AddAsync(expectedWorkOrder);
+            await InMemoryDb.Instance.SaveChangesAsync();
+
+            // act
+            var workOrders = await _classUnderTest.GetWorkOrders(wo =>
+                wo.StatusCode  == WorkStatusCode.Hold);
+
+            // assert
+            workOrders.Should().ContainSingle().Which.Should().BeEquivalentTo(expectedWorkOrder);
+        }
+
+        [Test]
         public async Task CanGetWorkOrderById()
         {
             // arrange
@@ -192,6 +209,26 @@ namespace RepairsApi.Tests.V2.Gateways
                 {
                     ContractorReference = contractor
                 }
+            };
+            return expected;
+        }
+
+        private static WorkOrder CreateWorkOrderWithStatus(int statusCode = 0)
+        {
+            var expected = new WorkOrder
+            {
+                WorkPriority = new WorkPriority
+                {
+                    PriorityCode = RepairsApi.V2.Generated.WorkPriorityCode._1,
+                    RequiredCompletionDateTime = DateTime.UtcNow
+                },
+                WorkClass = new WorkClass
+                {
+                    WorkClassCode = RepairsApi.V2.Generated.WorkClassCode._0
+                },
+                WorkElements = new List<WorkElement>(),
+                DescriptionOfWork = "description",
+                StatusCode = (WorkStatusCode) Enum.Parse(typeof(WorkStatusCode), statusCode.ToString())
             };
             return expected;
         }

--- a/RepairsApi.Tests/V2/Gateways/RepairGatewayTests.cs
+++ b/RepairsApi.Tests/V2/Gateways/RepairGatewayTests.cs
@@ -105,7 +105,7 @@ namespace RepairsApi.Tests.V2.Gateways
 
             // act
             var workOrders = await _classUnderTest.GetWorkOrders(wo =>
-                wo.StatusCode  == WorkStatusCode.Hold);
+                wo.StatusCode == WorkStatusCode.Hold);
 
             // assert
             workOrders.Should().ContainSingle().Which.Should().BeEquivalentTo(expectedWorkOrder);

--- a/RepairsApi/V2/Controllers/Parameters/WorkOrderSearchParameters.cs
+++ b/RepairsApi/V2/Controllers/Parameters/WorkOrderSearchParameters.cs
@@ -7,6 +7,7 @@ namespace RepairsApi.V2.Controllers.Parameters
         public static int MaxPageSize { get; } = 50;
         public string PropertyReference { get; set; }
         public string ContractorReference { get; set; }
+        public int StatusCode { get; set; }
         public int PageNumber { get; set; } = 1;
         private int _pageSize = 10;
         public int PageSize

--- a/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
@@ -48,6 +48,11 @@ namespace RepairsApi.V2.UseCase
                 result.Add(wo => wo.AssignedToPrimary.ContractorReference == searchParameters.ContractorReference);
             }
 
+            if(searchParameters.StatusCode > 0 && Enum.IsDefined(typeof(WorkStatusCode), searchParameters.StatusCode))
+            {
+                result.Add(wo => wo.StatusCode == (WorkStatusCode) Enum.Parse(typeof(WorkStatusCode), searchParameters.StatusCode.ToString()));
+            }
+
             return result.ToArray();
         }
     }

--- a/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
@@ -48,7 +48,7 @@ namespace RepairsApi.V2.UseCase
                 result.Add(wo => wo.AssignedToPrimary.ContractorReference == searchParameters.ContractorReference);
             }
 
-            if(searchParameters.StatusCode > 0 && Enum.IsDefined(typeof(WorkStatusCode), searchParameters.StatusCode))
+            if (searchParameters.StatusCode > 0 && Enum.IsDefined(typeof(WorkStatusCode), searchParameters.StatusCode))
             {
                 result.Add(wo => wo.StatusCode == (WorkStatusCode) Enum.Parse(typeof(WorkStatusCode), searchParameters.StatusCode.ToString()));
             }


### PR DESCRIPTION
## Link to Trello ticket

https://trello.com/c/RaKeUK2Q/26-as-a-contract-manager-i-can-log-in-and-see-a-list-of-orders-so-that-i-know-which-ones-i-need-to-action

## Describe this PR

Work orders need to be filtered by status

### *What is the problem we're trying to solve*

When listing work orders we need to be able filter by status

### *What changes have we introduced*

Added another option to WorkOrderSearchParameters on GET /api/v2/repairs/.
Added extra param to the Gateway search.
Added test for gw.