### PR TITLE
Update postgres version

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -49,7 +49,7 @@ module "postgres_db_production" {
   db_port  = 5830
   subnet_ids = data.aws_subnet_ids.production.ids
   db_engine = "postgres"
-  db_engine_version = "11.10" //DMS does not work well with v12
+  db_engine_version = "12." 
   db_instance_class = "db.t3.medium"
   db_allocated_storage = 100
   maintenance_window = "sun:01:00-sun:01:30"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -49,8 +49,8 @@ module "postgres_db_staging" {
   db_port  = 5829
   subnet_ids = data.aws_subnet_ids.staging.ids
   db_engine = "postgres"
-  db_engine_version = "11.10" //DMS does not work well with v12
-  db_instance_class = "db.t2.micro"
+  db_engine_version = "12." 
+  db_instance_class = "db.t3.medium"
   db_allocated_storage = 20
   maintenance_window = "sun:10:00-sun:10:30"
   db_username = data.aws_ssm_parameter.repairs_postgres_username.value


### PR DESCRIPTION
Updated Postgres version manually in both staging and production.
Updated terraform to only apply on major versions ("12.") means it'll not worry about anything within the major version 12.
Also updated staging instance type so it's the same as production.