### PR TITLE
variation column ef migration

### DIFF
--- a/RepairsApi/Startup.cs
+++ b/RepairsApi/Startup.cs
@@ -35,7 +35,6 @@ namespace RepairsApi
     public class Startup
     {
         private readonly IWebHostEnvironment _env;
-
         public Startup(IConfiguration configuration, IWebHostEnvironment env)
         {
             _env = env;

--- a/RepairsApi/V2/Infrastructure/Migrations/20210322152700_AddVariationsColumnToWorkorder.Designer.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210322152700_AddVariationsColumnToWorkorder.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RepairsApi.V2.Infrastructure;
@@ -9,9 +10,10 @@ using RepairsApi.V2.Infrastructure;
 namespace RepairsApi.V2.Infrastructure.Migrations
 {
     [DbContext(typeof(RepairsContext))]
-    partial class RepairsContextModelSnapshot : ModelSnapshot
+    [Migration("20210322152700_AddVariationsColumnToWorkorder")]
+    partial class AddVariationsColumnToWorkorder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RepairsApi/V2/Infrastructure/Migrations/20210322152700_AddVariationsColumnToWorkorder.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210322152700_AddVariationsColumnToWorkorder.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RepairsApi.V2.Infrastructure.Migrations
+{
+    public partial class AddVariationsColumnToWorkorder : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "has_variation",
+                table: "work_orders",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "has_variation",
+                table: "work_orders");
+        }
+    }
+}

--- a/RepairsApi/V2/Infrastructure/Migrations/20210322161406_AddBooleanVariationsColumnToWorkorder.Designer.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210322161406_AddBooleanVariationsColumnToWorkorder.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RepairsApi.V2.Infrastructure;
@@ -9,9 +10,10 @@ using RepairsApi.V2.Infrastructure;
 namespace RepairsApi.V2.Infrastructure.Migrations
 {
     [DbContext(typeof(RepairsContext))]
-    partial class RepairsContextModelSnapshot : ModelSnapshot
+    [Migration("20210322161406_AddBooleanVariationsColumnToWorkorder")]
+    partial class AddBooleanVariationsColumnToWorkorder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RepairsApi/V2/Infrastructure/Migrations/20210322161406_AddBooleanVariationsColumnToWorkorder.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210322161406_AddBooleanVariationsColumnToWorkorder.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RepairsApi.V2.Infrastructure.Migrations
+{
+    public partial class AddBooleanVariationsColumnToWorkorder : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "has_variation",
+                table: "work_orders",
+                type: "boolean",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "has_variation",
+                table: "work_orders",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean");
+        }
+    }
+}

--- a/RepairsApi/V2/Infrastructure/Migrations/20210322161828_AddVariationsColumnDefaultValue.Designer.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210322161828_AddVariationsColumnDefaultValue.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RepairsApi.V2.Infrastructure;
@@ -9,9 +10,10 @@ using RepairsApi.V2.Infrastructure;
 namespace RepairsApi.V2.Infrastructure.Migrations
 {
     [DbContext(typeof(RepairsContext))]
-    partial class RepairsContextModelSnapshot : ModelSnapshot
+    [Migration("20210322161828_AddVariationsColumnDefaultValue")]
+    partial class AddVariationsColumnDefaultValue
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RepairsApi/V2/Infrastructure/Migrations/20210322161828_AddVariationsColumnDefaultValue.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210322161828_AddVariationsColumnDefaultValue.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RepairsApi.V2.Infrastructure.Migrations
+{
+    public partial class AddVariationsColumnDefaultValue : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/RepairsApi/V2/Infrastructure/WorkOrder.cs
+++ b/RepairsApi/V2/Infrastructure/WorkOrder.cs
@@ -34,6 +34,7 @@ namespace RepairsApi.V2.Infrastructure
         // Extensions
         public string AgentName { get; set; }
         public WorkStatusCode StatusCode { get; set; } = WorkStatusCode.Open;
+        public VariationStatusCode HasVariation { get; set; } = VariationStatusCode.Outstanding;
     }
 
     public enum WorkStatusCode
@@ -54,6 +55,12 @@ namespace RepairsApi.V2.Infrastructure
 
         // Extensions
         NoAccess = 1000,
+    }
+
+    public enum VariationStatusCode
+    {
+        Resolved = 0,
+        Outstanding = 1
     }
 
     [Owned]

--- a/RepairsApi/V2/Infrastructure/WorkOrder.cs
+++ b/RepairsApi/V2/Infrastructure/WorkOrder.cs
@@ -34,7 +34,7 @@ namespace RepairsApi.V2.Infrastructure
         // Extensions
         public string AgentName { get; set; }
         public WorkStatusCode StatusCode { get; set; } = WorkStatusCode.Open;
-        public VariationStatusCode HasVariation { get; set; } = VariationStatusCode.Outstanding;
+        public bool HasVariation { get; set; } = false;
     }
 
     public enum WorkStatusCode
@@ -55,12 +55,6 @@ namespace RepairsApi.V2.Infrastructure
 
         // Extensions
         NoAccess = 1000,
-    }
-
-    public enum VariationStatusCode
-    {
-        Resolved = 0,
-        Outstanding = 1
     }
 
     [Owned]


### PR DESCRIPTION
## Link to JIRA ticket

https://trello.com/c/GPKJdNkN/13-as-a-contractor-i-can-see-the-status-of-a-variation-so-that-i-know-whether-to-proceed-with-the-work-or-not

## Describe this PR

### *What is the problem we're trying to solve*

Track workorder  object variation status

### *What changes have we introduced*

Added column for variation status. Column stored as int/enum.


#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Return variation status field in workorder  response object
