### PR TITLE
add boolean column for variations to work order table

### DIFF
--- a/RepairsApi/V2/Boundary/WorkOrderResponse.cs
+++ b/RepairsApi/V2/Boundary/WorkOrderResponse.cs
@@ -23,5 +23,6 @@ namespace RepairsApi.V2.Boundary
         public string TradeCode { get; set; }
         public string TradeDescription { get; set; }
         public AppointmentResponse Appointment { get; set; }
+        public bool HasVariation { get; set; }
     }
 }

--- a/RepairsApi/V2/Factories/ResponseFactory.cs
+++ b/RepairsApi/V2/Factories/ResponseFactory.cs
@@ -147,6 +147,7 @@ namespace RepairsApi.V2.Factories
                 ContractorReference = workOrder.AssignedToPrimary?.ContractorReference,
                 TradeCode = workOrder.WorkElements.FirstOrDefault()?.Trade.FirstOrDefault()?.CustomCode,
                 TradeDescription = workOrder.WorkElements.FirstOrDefault()?.Trade.FirstOrDefault()?.CustomName,
+                HasVariation = workOrder.HasVariation,
                 Appointment = appointment is null ? null : new AppointmentResponse
                 {
                     Date = appointment.Date.Date.ToDate(),

--- a/RepairsApi/V2/Infrastructure/Migrations/20210323140500_AddBooleanVariationsColumnToWorkorder.Designer.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210323140500_AddBooleanVariationsColumnToWorkorder.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RepairsApi.V2.Infrastructure;
@@ -9,9 +10,10 @@ using RepairsApi.V2.Infrastructure;
 namespace RepairsApi.V2.Infrastructure.Migrations
 {
     [DbContext(typeof(RepairsContext))]
-    partial class RepairsContextModelSnapshot : ModelSnapshot
+    [Migration("20210323140500_AddBooleanVariationsColumnToWorkorder")]
+    partial class AddBooleanVariationsColumnToWorkorder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RepairsApi/V2/Infrastructure/Migrations/20210323140500_AddBooleanVariationsColumnToWorkorder.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210323140500_AddBooleanVariationsColumnToWorkorder.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RepairsApi.V2.Infrastructure.Migrations
+{
+    public partial class AddBooleanVariationsColumnToWorkorder : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "has_variation",
+                table: "work_orders",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "has_variation",
+                table: "work_orders");
+        }
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://trello.com/c/GPKJdNkN/13-as-a-contractor-i-can-see-the-status-of-a-variation-so-that-i-know-whether-to-proceed-with-the-work-or-not

## Describe this PR

### *What is the problem we're trying to solve*

Add boolean column to workorder table for variations

### *What changes have we introduced*

EF Migration

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Update workorder object to return variation column in response.
