### PR TITLE
Stop XRay intercepting in EF migration context

### DIFF
--- a/RepairsApi/appsettings.Development.json
+++ b/RepairsApi/appsettings.Development.json
@@ -17,5 +17,5 @@
     "HousingResidentInformationApi": "http://testresidentsapi",
     "HousingResidentInformationApiKey": "dummykey"
   },
-  "DatabaseConnectionString": "Host=127.0.0.1;Port=5432;Username=postgres;Password=mypassword;Database=testdb"
+  "DatabaseConnectionString": "Host=127.0.0.1;Port=5432;Username=postgres;Password=mypassword;Database=testdb",
 }


### PR DESCRIPTION
## Trello: [Add AWS X-Ray to API](https://trello.com/c/v4m5P1rd)

The previous commit to enable this caused the EF migration to fail. I *think* this is because the AWS XRay handler is attempting to invoke in an environment that isn't running on Lambda (the `dotnet ef database update` call).

This is an attempt to mitigate that by checking (in an ugly way... happy to hear suggestions) if we are executing in Lambda, and disabling the X-Ray handling if not.