### PR TITLE
Use "Variation Pending Approval"

### DIFF
--- a/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
+++ b/RepairsApi.Tests/V2/E2ETests/RepairApiTests.cs
@@ -264,7 +264,7 @@ namespace RepairsApi.Tests.V2.E2ETests
             var workOrder = GetWorkOrderWithJobStatusUpdatesFromDB(workOrderId);
 
             // Assert
-            workOrder.StatusCode.Should().Be(WorkStatusCode.PendApp);
+            workOrder.StatusCode.Should().Be(WorkStatusCode.VariationPendingApproval);
             workOrder.JobStatusUpdates[0].TypeCode.Should().Be(JobStatusUpdateTypeCode._180);
         }
 

--- a/RepairsApi.Tests/V2/UseCase/JobStatusUpdateUseCases/RejectVariationTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/JobStatusUpdateUseCases/RejectVariationTests.cs
@@ -71,7 +71,7 @@ namespace RepairsApi.Tests.V2.UseCase.JobStatusUpdateUseCases
         {
             const int desiredWorkOrderId = 42;
             var workOrder = CreateReturnWorkOrder(desiredWorkOrderId);
-            workOrder.StatusCode = WorkStatusCode.PendApp;
+            workOrder.StatusCode = WorkStatusCode.VariationPendingApproval;
             var request = CreateJobStatusUpdateRequest(desiredWorkOrderId,
                 Generated.JobStatusUpdateTypeCode._125);
 

--- a/RepairsApi.Tests/V2/UseCase/ListWorkOrdersUseCaseTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/ListWorkOrdersUseCaseTests.cs
@@ -155,7 +155,7 @@ namespace RepairsApi.Tests.V2.UseCase
             };
             var statusOrder = new[] {
                 WorkOrderStatus.InProgress,
-                WorkOrderStatus.PendApp,
+                WorkOrderStatus.VariationPendingApproval,
                 WorkOrderStatus.Cancelled,
                 WorkOrderStatus.Complete,
                 WorkOrderStatus.Unknown

--- a/RepairsApi/V2/Boundary/Response/WorkOrderListItem.cs
+++ b/RepairsApi/V2/Boundary/Response/WorkOrderListItem.cs
@@ -8,7 +8,7 @@ namespace RepairsApi.V2.Boundary.Response
         public const string Complete = "Work Complete";
         public const string Cancelled = "Work Cancelled";
         public const string Hold = "On Hold";
-        public const string PendApp = "Pending Approval";
+        public const string PendApp = "Variation Pending Approval";
         public const string PendMaterial = "Materials Needed";
         public const string VariationApproved = "Variation Approved";
         public const string VariationRejected = "Variation Rejected";
@@ -19,7 +19,7 @@ namespace RepairsApi.V2.Boundary.Response
     {
         public const string Approved = "Variation Approved";
         public const string Rejected = "Variation Rejected";
-        public const string PendAuthorisation = "Pending Authorisation";
+        public const string PendAuthorisation = "Variation Pending Authorisation";
         public const string Unknown = "Unknown";
     }
 

--- a/RepairsApi/V2/Boundary/Response/WorkOrderListItem.cs
+++ b/RepairsApi/V2/Boundary/Response/WorkOrderListItem.cs
@@ -8,7 +8,7 @@ namespace RepairsApi.V2.Boundary.Response
         public const string Complete = "Work Complete";
         public const string Cancelled = "Work Cancelled";
         public const string Hold = "On Hold";
-        public const string PendApp = "Variation Pending Approval";
+        public const string VariationPendingApproval = "Variation Pending Approval";
         public const string PendMaterial = "Materials Needed";
         public const string VariationApproved = "Variation Approved";
         public const string VariationRejected = "Variation Rejected";
@@ -19,7 +19,7 @@ namespace RepairsApi.V2.Boundary.Response
     {
         public const string Approved = "Variation Approved";
         public const string Rejected = "Variation Rejected";
-        public const string PendAuthorisation = "Variation Pending Authorisation";
+        public const string VariationPendingAuthorisation = "Variation Pending Authorisation";
         public const string Unknown = "Unknown";
     }
 

--- a/RepairsApi/V2/Infrastructure/Extensions/WorkOrderExtensions.cs
+++ b/RepairsApi/V2/Infrastructure/Extensions/WorkOrderExtensions.cs
@@ -12,7 +12,7 @@ namespace RepairsApi.V2.Infrastructure.Extensions
                 WorkStatusCode.Complete => WorkOrderStatus.Complete,
                 WorkStatusCode.Canceled => WorkOrderStatus.Cancelled,
                 WorkStatusCode.Hold => WorkOrderStatus.Hold,
-                WorkStatusCode.PendApp => WorkOrderStatus.PendApp,
+                WorkStatusCode.VariationPendingApproval => WorkOrderStatus.VariationPendingApproval,
                 WorkStatusCode.PendMaterial => WorkOrderStatus.PendMaterial,
                 WorkStatusCode.VariationApproved => WorkOrderStatus.VariationApproved,
                 WorkStatusCode.VariationRejected => WorkOrderStatus.VariationRejected,
@@ -24,7 +24,7 @@ namespace RepairsApi.V2.Infrastructure.Extensions
         {
             return workOrder.Reason switch
             {
-                ReasonCode.PendingAuthorisation => WorkOrderReason.PendAuthorisation,
+                ReasonCode.VariationPendingAuthorisation => WorkOrderReason.VariationPendingAuthorisation,
                 ReasonCode.NoApproval => WorkOrderReason.Rejected,
                 ReasonCode.Approved => WorkOrderReason.Approved,
                 _ => WorkOrderReason.Unknown,

--- a/RepairsApi/V2/Infrastructure/WorkOrder.cs
+++ b/RepairsApi/V2/Infrastructure/WorkOrder.cs
@@ -48,7 +48,7 @@ namespace RepairsApi.V2.Infrastructure
         Estimating = 60, // Estimating: Work Is Being Estimated. Active.
         Hold = 70, // Hold: Work Is On Hold - See Reason Code. Active
         Open = 80, // Open: Work Order Is Open - Initial Status For All Work Orders. Active.
-        PendApp = 90, // Pend App: Work Order Is Pending Approval. Active.
+        VariationPendingApproval = 90, // Pend App: Work Order Is Pending Approval. Active.
         PendDesign = 100, // Pend Design: Work Order Is Pending Design Or Design Documents. Active.
         PendMaterial = 110, // Pend Material: Work Order Is Pending Materials. Active.
         Scheduled = 120, // Scheduled: Work Is Scheduled Using A Scheduling Tool. Active.
@@ -70,7 +70,7 @@ namespace RepairsApi.V2.Infrastructure
         NoApproval = 60,    //No Approval: Work Was Not Approved
         Approved = 70,      //Approved: All Required Approvals Are Present
         Priority = 80,   //Change Priority Changed Either Escalated Or De-Escalated
-        PendingAuthorisation = 90 //Pending authorisation
+        VariationPendingAuthorisation = 90 //Pending authorisation
     }
 
     [Owned]

--- a/RepairsApi/V2/UseCase/CompleteWorkOrderUseCase.cs
+++ b/RepairsApi/V2/UseCase/CompleteWorkOrderUseCase.cs
@@ -43,7 +43,7 @@ namespace RepairsApi.V2.UseCase
             }
 
             var workOrder = await _repairsGateway.GetWorkOrder(workOrderId);
-            if (workOrder.StatusCode == WorkStatusCode.PendApp)
+            if (workOrder.StatusCode == WorkStatusCode.VariationPendingApproval)
                 throw new UnauthorizedAccessException("Work Orders pending approval can not be completed.");
 
             ValidateRequest(workOrderComplete);

--- a/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/ApproveVariationUseCase.cs
+++ b/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/ApproveVariationUseCase.cs
@@ -34,7 +34,7 @@ namespace RepairsApi.V2.UseCase.JobStatusUpdatesUseCases
             if (!_currentUserService.HasGroup(UserGroups.CONTRACT_MANAGER))
                 throw new UnauthorizedAccessException("You do not have the correct permissions for this action");
 
-            if (workOrder.StatusCode != WorkStatusCode.PendApp)
+            if (workOrder.StatusCode != WorkStatusCode.VariationPendingApproval)
                 throw new NotSupportedException("This action is not permitted");
 
             var variationJobStatus = await _jobStatusUpdateGateway.SelectLastJobStatusUpdate

--- a/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/MoreSpecificSorUseCase.cs
+++ b/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/MoreSpecificSorUseCase.cs
@@ -44,13 +44,13 @@ namespace RepairsApi.V2.UseCase.JobStatusUpdatesUseCases
             var authorised = await _authorizationService.AuthorizeAsync(_currentUserService.GetUser(), jobStatusUpdate, "VarySpendLimit");
 
             //The workorder already has a variation
-            if (workOrder.StatusCode == WorkStatusCode.PendApp &&
+            if (workOrder.StatusCode == WorkStatusCode.VariationPendingApproval &&
                 jobStatusUpdate.TypeCode == JobStatusUpdateTypeCode._80)
                 throw new InvalidOperationException("This action is not permitted");
 
             if (await _featureManager.IsEnabledAsync(FeatureFlags.SPENDLIMITS) && !authorised.Succeeded)
             {
-                workOrder.StatusCode = WorkStatusCode.PendApp;
+                workOrder.StatusCode = WorkStatusCode.VariationPendingApproval;
                 jobStatusUpdate.TypeCode = JobStatusUpdateTypeCode._180;
             }
             //User authorised, patch SOR codes

--- a/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/RejectVariationUseCase.cs
+++ b/RepairsApi/V2/UseCase/JobStatusUpdatesUseCases/RejectVariationUseCase.cs
@@ -29,7 +29,7 @@ namespace RepairsApi.V2.UseCase.JobStatusUpdatesUseCases
             if (!_currentUserService.HasGroup(UserGroups.CONTRACT_MANAGER))
                 throw new UnauthorizedAccessException("You do not have the correct permissions for this action");
 
-            if (workOrder.StatusCode != WorkStatusCode.PendApp)
+            if (workOrder.StatusCode != WorkStatusCode.VariationPendingApproval)
                 throw new NotSupportedException("This action is not permitted");
 
             workOrder.StatusCode = WorkStatusCode.VariationRejected;

--- a/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
@@ -31,7 +31,7 @@ namespace RepairsApi.V2.UseCase
 
             var statusOrder = new[] {
                 WorkOrderStatus.InProgress,
-                WorkOrderStatus.PendApp,
+                WorkOrderStatus.VariationPendingApproval,
                 WorkOrderStatus.Cancelled,
                 WorkOrderStatus.Complete,
                 WorkOrderStatus.Unknown

--- a/RepairsApi/appsettings.json
+++ b/RepairsApi/appsettings.json
@@ -28,7 +28,7 @@
         },
         {
           "Key": "90",
-          "Description": "Pending Approval"
+          "Description": "Variation Pending Approval"
         },
         {
           "Key": "110",


### PR DESCRIPTION
## [Trello: As a contract manager, I can see if a request is variation pending approval, so that I know which repairs to approve](https://trello.com/c/uWW6pSKg)


 - Changes *Pending Approval* to *Variation Pending Approval* in `WorkOrderStatus`.
 - Changes *Pending Authorisation* to *Variation Pending Authorisation* in `WorkOrderReason`.