### PR TITLE
Add ResourcePolicy for DRS Receiver SOAP endpoint

### DIFF
--- a/RepairsApi/serverless.yml
+++ b/RepairsApi/serverless.yml
@@ -18,6 +18,15 @@ provider:
   tracing:
     lambda: true
     apiGateway: true
+  resourcePolicy:
+    - Effect: Deny
+      Principal: "*"
+      Action: execute-api:Invoke
+      Resource:
+        - ${ssm:/${self:service}/${self:provider.stage}/drs-receiver-arn}
+      Condition:
+        NotIpAddress:
+          aws:SourceIp: ${ssm:/${self:service}/${self:provider.stage}/drs-receiver-allow-ips~split}
 
 package:
   artifact: ./bin/release/netcoreapp3.1/repairs-api.zip


### PR DESCRIPTION
Adds Resource Policy for the DRS Receiver SOAP endpoint
> DenyAll -> Allow DRS provided IPs