### PR TITLE
Checking in migration script

### DIFF
--- a/sql/operative-migration.sql
+++ b/sql/operative-migration.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+do $$
+declare
+   operative_record RECORD;
+   operative_id integer;
+   archived boolean;
+begin
+	FOR operative_record IN SELECT * FROM dbo.drs_operative_dump
+	LOOP
+		IF operative_record."NumberOfResources" > 0 THEN
+			archived := false;
+		ELSE
+			archived := true;
+		END IF;
+		INSERT INTO public.operatives (payroll_number, is_archived, name)
+			VALUES (operative_record."ExternalResourceCode", archived, operative_record."ResourceName")
+			RETURNING id INTO operative_id;
+	end loop;
+end; $$
+;
+
+COMMIT;


### PR DESCRIPTION
-- This is being maintained as a seperate script rather than code first as it relies on tables not maintained by EF (in this instance the drs_operative_dump table)
