### PR TITLE
Only go to navigation properties on items in the page

### DIFF
--- a/RepairsApi.Tests/V2/UseCase/ListWorkOrdersUseCaseTests.cs
+++ b/RepairsApi.Tests/V2/UseCase/ListWorkOrdersUseCaseTests.cs
@@ -159,11 +159,10 @@ namespace RepairsApi.Tests.V2.UseCase
                 PageSize = expectedPageSize
             };
             var statusOrder = new[] {
-                WorkOrderStatus.InProgress,
-                WorkOrderStatus.VariationPendingApproval,
-                WorkOrderStatus.Cancelled,
-                WorkOrderStatus.Complete,
-                WorkOrderStatus.Unknown
+                WorkStatusCode.Open,
+                WorkStatusCode.VariationPendingApproval,
+                WorkStatusCode.Canceled,
+                WorkStatusCode.Complete
             };
 
             //Act
@@ -171,7 +170,7 @@ namespace RepairsApi.Tests.V2.UseCase
 
             //Assert
             var expectedResult = generatedWorkOrders
-                .OrderBy(wo => Array.IndexOf(statusOrder, wo.GetStatus()))
+                .OrderBy(wo => Array.IndexOf(statusOrder, wo.StatusCode))
                 .ThenByDescending(wo => wo.DateRaised)
                 .Skip((workOrderSearchParameters.PageNumber - 1) * workOrderSearchParameters.PageSize)
                 .Take(workOrderSearchParameters.PageSize)

--- a/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
@@ -27,14 +27,13 @@ namespace RepairsApi.V2.UseCase
         public async Task<IEnumerable<WorkOrderListItem>> Execute(WorkOrderSearchParameters searchParameters)
         {
             var filter = _filterBuilder.BuildFilter(searchParameters);
-            IEnumerable<WorkOrder> workOrders = await _repairsGateway.GetWorkOrders(filter);
+            var workOrders = await _repairsGateway.GetWorkOrders(filter);
 
             var statusOrder = new[] {
-                WorkOrderStatus.InProgress,
-                WorkOrderStatus.VariationPendingApproval,
-                WorkOrderStatus.Cancelled,
-                WorkOrderStatus.Complete,
-                WorkOrderStatus.Unknown
+                WorkStatusCode.Open,
+                WorkStatusCode.VariationPendingApproval,
+                WorkStatusCode.Canceled,
+                WorkStatusCode.Complete
             };
 
             return workOrders

--- a/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
+++ b/RepairsApi/V2/UseCase/ListWorkOrdersUseCase.cs
@@ -37,11 +37,12 @@ namespace RepairsApi.V2.UseCase
                 WorkOrderStatus.Unknown
             };
 
-            return workOrders.Select(wo => wo.ToListItem())
-                .OrderBy(wo => Array.IndexOf(statusOrder, wo.Status))
+            return workOrders
+                .OrderBy(wo => Array.IndexOf(statusOrder, wo.StatusCode))
                 .ThenByDescending(wo => wo.DateRaised)
                 .Skip((searchParameters.PageNumber - 1) * searchParameters.PageSize)
                 .Take(searchParameters.PageSize)
+                .Select(wo => wo.ToListItem())
                 .ToList();
         }
     }


### PR DESCRIPTION
Getting navigation properties causes queries as we use lazy proxies. Therefore we should select on queried object last.

With this change only the page size of objects will have navigation proepties loaded