### PR TITLE
Adding locked status for migrated work orders

### DIFF
--- a/RepairsApi/V2/Boundary/Response/WorkOrderListItem.cs
+++ b/RepairsApi/V2/Boundary/Response/WorkOrderListItem.cs
@@ -14,6 +14,7 @@ namespace RepairsApi.V2.Boundary.Response
         public const string VariationApproved = "Variation Approved";
         public const string VariationRejected = "Variation Rejected";
         public const string NoAccess = "No Access";
+        public const string Locked = "Locked";
         public const string Unknown = "Unknown";
     }
 

--- a/RepairsApi/V2/Infrastructure/Extensions/WorkOrderExtensions.cs
+++ b/RepairsApi/V2/Infrastructure/Extensions/WorkOrderExtensions.cs
@@ -18,6 +18,7 @@ namespace RepairsApi.V2.Infrastructure.Extensions
                 WorkStatusCode.VariationApproved => WorkOrderStatus.VariationApproved,
                 WorkStatusCode.VariationRejected => WorkOrderStatus.VariationRejected,
                 WorkStatusCode.NoAccess => WorkOrderStatus.NoAccess,
+                WorkStatusCode.Locked => WorkOrderStatus.Locked,
                 _ => WorkOrderStatus.Unknown,
             };
         }

--- a/RepairsApi/V2/Infrastructure/WorkOrder.cs
+++ b/RepairsApi/V2/Infrastructure/WorkOrder.cs
@@ -132,6 +132,11 @@ namespace RepairsApi.V2.Infrastructure
         /// </summary>
         Superceded = 130,
 
+        /// <summary>
+        /// Locked: Work Order is disputed (used for migrated data)
+        /// </summary>
+        Locked = 200,
+
         // Extensions
         NoAccess = 1000,
         PendingApproval = 1010,


### PR DESCRIPTION
Very small change to introduce the "locked" status for migrated data that is still under dispute