### PR TITLE
Added closed date field to work order populated on completion

### DIFF
--- a/RepairsApi.Tests/E2ETests/Repairs/RepairApiTests.cs
+++ b/RepairsApi.Tests/E2ETests/Repairs/RepairApiTests.cs
@@ -227,14 +227,16 @@ namespace RepairsApi.Tests.E2ETests.Repairs
         public async Task CompleteWorkOrder()
         {
             // Arrange
+            var eventTime = DateTime.Now;
             var result = await CreateWorkOrder();
             SetUserRole(UserGroups.Contractor);
-            var code = await CompleteWorkOrder(result.Id);
+            var code = await CompleteWorkOrder(result.Id, true, woc => woc.JobStatusUpdates.First().EventTime = eventTime);
             var workOrder = GetWorkOrderFromDB(result.Id);
 
             // Assert
             code.Should().Be(HttpStatusCode.OK);
             workOrder.StatusCode.Should().Be(WorkStatusCode.Complete);
+            workOrder.ClosedDate.Should().BeSameDateAs(eventTime);
         }
 
         private async Task<HttpStatusCode> CompleteWorkOrder(int workOrderId, bool preAssignOperative = true, Action<WorkOrderComplete> interceptor = null)

--- a/RepairsApi/V2/Boundary/WorkOrderResponse.cs
+++ b/RepairsApi/V2/Boundary/WorkOrderResponse.cs
@@ -29,5 +29,6 @@ namespace RepairsApi.V2.Boundary
         public string Action { get; set; }
         public Uri ExternalAppointmentManagementUrl { get; set; }
         public bool CanAssignOperative { get; set; }
+        public DateTime? ClosedDated { get; set; }
     }
 }

--- a/RepairsApi/V2/Factories/ResponseFactory.cs
+++ b/RepairsApi/V2/Factories/ResponseFactory.cs
@@ -162,7 +162,8 @@ namespace RepairsApi.V2.Factories
                 },
                 ExternalAppointmentManagementUrl = managementUri,
                 Operatives = workOrder.AssignedOperatives.MapList(o => o.ToResponse()),
-                CanAssignOperative = canAssignOperative
+                CanAssignOperative = canAssignOperative,
+                ClosedDated = workOrder.ClosedDate
             };
         }
 

--- a/RepairsApi/V2/Infrastructure/Migrations/20210713110556_CloseDate.Designer.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210713110556_CloseDate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RepairsApi.V2.Infrastructure;
@@ -9,9 +10,10 @@ using RepairsApi.V2.Infrastructure;
 namespace RepairsApi.V2.Infrastructure.Migrations
 {
     [DbContext(typeof(RepairsContext))]
-    partial class RepairsContextModelSnapshot : ModelSnapshot
+    [Migration("20210713110556_CloseDate")]
+    partial class CloseDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RepairsApi/V2/Infrastructure/Migrations/20210713110556_CloseDate.cs
+++ b/RepairsApi/V2/Infrastructure/Migrations/20210713110556_CloseDate.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace RepairsApi.V2.Infrastructure.Migrations
+{
+    public partial class CloseDate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "closed_date",
+                table: "work_orders",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+UPDATE public.work_orders wo SET closed_date = jsu.event_time
+FROM public.job_status_updates jsu 
+WHERE wo.id = jsu.work_order_complete_id
+");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "closed_date",
+                table: "work_orders");
+        }
+    }
+}

--- a/RepairsApi/V2/Infrastructure/WorkOrder.cs
+++ b/RepairsApi/V2/Infrastructure/WorkOrder.cs
@@ -37,6 +37,7 @@ namespace RepairsApi.V2.Infrastructure
         public virtual List<WorkOrderOperative> WorkOrderOperatives { get; set; }
         public virtual List<Operative> AssignedOperatives { get; set; }
         public string ExternalSchedulerReference { get; set; }
+        public DateTime? ClosedDate { get; set; }
     }
 
     public class WorkOrderOperative

--- a/RepairsApi/V2/UseCase/CompleteWorkOrderUseCase.cs
+++ b/RepairsApi/V2/UseCase/CompleteWorkOrderUseCase.cs
@@ -89,6 +89,8 @@ namespace RepairsApi.V2.UseCase
                     break;
                 default: throw new NotSupportedException(Resources.UnsupportedWorkOrderUpdate);
             }
+
+            workOrder.ClosedDate = update.EventTime;
         }
 
         private async Task HandleCustomType(WorkOrder workOrder, JobStatusUpdate update)


### PR DESCRIPTION
This ticket adds a closed date field to the work order that is set when running the complete order usecase. its is backfilled with the same logic used to set it